### PR TITLE
Fix #30: generate statistics about the number of total levels in the book, including empty ones

### DIFF
--- a/jb/itch5/order_book.cpp
+++ b/jb/itch5/order_book.cpp
@@ -8,10 +8,26 @@ jb::itch5::half_quote jb::itch5::order_book::best_bid() const {
   return half_quote(i->first, i->second);
 }
 
+jb::itch5::half_quote jb::itch5::order_book::worst_bid() const {
+  if (buy_.empty()) {
+    return empty_bid();
+  }
+  auto i = buy_.rbegin();
+  return half_quote(i->first, i->second);
+}
+
 jb::itch5::half_quote jb::itch5::order_book::best_offer() const {
   if (sell_.empty()) {
     return empty_offer();
   }
   auto i = sell_.begin();
+  return half_quote(i->first, i->second);
+}
+
+jb::itch5::half_quote jb::itch5::order_book::worst_offer() const {
+  if (sell_.empty()) {
+    return empty_offer();
+  }
+  auto i = sell_.rbegin();
   return half_quote(i->first, i->second);
 }

--- a/jb/itch5/order_book.hpp
+++ b/jb/itch5/order_book.hpp
@@ -65,8 +65,12 @@ public:
 
   /// @returns the best bid price and quantity
   half_quote best_bid() const;
+  /// @returns the worst bid price and quantity
+  half_quote worst_bid() const;
   /// @returns the best offer price and quantity
   half_quote best_offer() const;
+  /// @returns the worst offer price and quantity
+  half_quote worst_offer() const;
 
   /// @returns the number of levels with non-zero quantity for the BUY side.
   std::size_t buy_count() const {

--- a/jb/itch5/price_levels.hpp
+++ b/jb/itch5/price_levels.hpp
@@ -18,13 +18,16 @@ namespace itch5 {
  */
 template <typename price_field_t>
 int price_levels(price_field_t lo, price_field_t hi) {
-  price_field_t const unit = price_field_t(price_field_t::denom);
-  price_field_t const penny = price_field_t(unit.as_integer() / 100);
-  price_field_t const mill = price_field_t(penny.as_integer() / 100);
-
   static_assert(
       price_field_t::denom >= 10000,
       "price_levels() does not work with denom < 10000");
+  static_assert(
+      price_field_t::denom % 10000 == 0,
+      "price_levels() does not work with (denom % 10000) != 0");
+
+  price_field_t const unit = price_field_t(price_field_t::denom);
+  auto constexpr penny = price_field_t::denom / 100;
+  auto constexpr mill = penny / 100;
 
   if (hi < lo) {
     throw std::range_error("invalid price range in price_levels()");
@@ -32,12 +35,12 @@ int price_levels(price_field_t lo, price_field_t hi) {
   if (unit <= lo) {
     // ... range is above $1.0, return the number of levels for that
     // case ...
-    return (hi.as_integer() - lo.as_integer()) / penny.as_integer();
+    return (hi.as_integer() - lo.as_integer()) / penny;
   }
   if (hi <= unit) {
     // ... range is below $1.0, return the number of levels for that
     // case ...
-    return (hi.as_integer() - lo.as_integer()) / mill.as_integer();
+    return (hi.as_integer() - lo.as_integer()) / mill;
   }
   // ... split the analysis ...
   return price_levels(lo, unit) + price_levels(unit, hi);

--- a/jb/itch5/ut_order_book.cpp
+++ b/jb/itch5/ut_order_book.cpp
@@ -12,7 +12,13 @@ BOOST_AUTO_TEST_CASE(order_book_trivial) {
   auto actual = tested.best_bid();
   BOOST_CHECK_EQUAL(actual.first, price4_t(0));
   BOOST_CHECK_EQUAL(actual.second, 0);
+  actual = tested.worst_bid();
+  BOOST_CHECK_EQUAL(actual.first, price4_t(0));
+  BOOST_CHECK_EQUAL(actual.second, 0);
   actual = tested.best_offer();
+  BOOST_CHECK_EQUAL(actual.first, price4_t(200000UL * 10000));
+  BOOST_CHECK_EQUAL(actual.second, 0);
+  actual = tested.worst_offer();
   BOOST_CHECK_EQUAL(actual.first, price4_t(200000UL * 10000));
   BOOST_CHECK_EQUAL(actual.second, 0);
   //  book_depth should be 0
@@ -35,8 +41,14 @@ BOOST_AUTO_TEST_CASE(order_book_buy) {
   auto actual = tested.best_offer();
   BOOST_CHECK_EQUAL(actual.first, price4_t(200000UL * 10000));
   BOOST_CHECK_EQUAL(actual.second, 0);
+  actual = tested.worst_offer();
+  BOOST_CHECK_EQUAL(actual.first, price4_t(200000UL * 10000));
+  BOOST_CHECK_EQUAL(actual.second, 0);
   // .. but the bid should ...
   actual = tested.best_bid();
+  BOOST_CHECK_EQUAL(actual.first, price4_t(100000));
+  BOOST_CHECK_EQUAL(actual.second, 100);
+  actual = tested.worst_bid();
   BOOST_CHECK_EQUAL(actual.first, price4_t(100000));
   BOOST_CHECK_EQUAL(actual.second, 100);
   // handler should return true... it is an inside change
@@ -49,6 +61,9 @@ BOOST_AUTO_TEST_CASE(order_book_buy) {
   actual = tested.best_bid();
   BOOST_CHECK_EQUAL(actual.first, price4_t(100000));
   BOOST_CHECK_EQUAL(actual.second, 100);
+  actual = tested.worst_bid();
+  BOOST_CHECK_EQUAL(actual.first, price4_t(99900));
+  BOOST_CHECK_EQUAL(actual.second, 300);
   // handler should return false
   BOOST_CHECK_EQUAL(r, false);
   // .. and the book_depth should be incremented
@@ -131,8 +146,14 @@ BOOST_AUTO_TEST_CASE(order_book_sell) {
   auto actual = tested.best_bid();
   BOOST_CHECK_EQUAL(actual.first, price4_t(0));
   BOOST_CHECK_EQUAL(actual.second, 0);
+  actual = tested.worst_bid();
+  BOOST_CHECK_EQUAL(actual.first, price4_t(0));
+  BOOST_CHECK_EQUAL(actual.second, 0);
   // .. but the offer should ...
   actual = tested.best_offer();
+  BOOST_CHECK_EQUAL(actual.first, price4_t(100000));
+  BOOST_CHECK_EQUAL(actual.second, 100);
+  actual = tested.worst_offer();
   BOOST_CHECK_EQUAL(actual.first, price4_t(100000));
   BOOST_CHECK_EQUAL(actual.second, 100);
   // handler should return true... it is an inside change
@@ -145,6 +166,10 @@ BOOST_AUTO_TEST_CASE(order_book_sell) {
   actual = tested.best_offer();
   BOOST_CHECK_EQUAL(actual.first, price4_t(100000));
   BOOST_CHECK_EQUAL(actual.second, 100);
+  // ... the worst offer should change though ...
+  actual = tested.worst_offer();
+  BOOST_CHECK_EQUAL(actual.first, price4_t(100100));
+  BOOST_CHECK_EQUAL(actual.second, 300);
   // handler should return false
   BOOST_CHECK_EQUAL(r, false);
   // .. and the book_depth should be incremented

--- a/tools/itch5bookdepth.cpp
+++ b/tools/itch5bookdepth.cpp
@@ -9,6 +9,7 @@
  * for design and implementation details.
  */
 #include <jb/itch5/compute_book.hpp>
+#include <jb/itch5/price_levels.hpp>
 #include <jb/itch5/process_iostream.hpp>
 #include <jb/book_depth_statistics.hpp>
 #include <jb/fileio.hpp>
@@ -45,7 +46,11 @@ void record_book_depth(
     jb::book_depth_statistics& stats, jb::itch5::message_header const&,
     jb::itch5::order_book const& book,
     jb::itch5::compute_book::book_update const& update) {
-  stats.sample(book.get_book_depth());
+  auto buy_price_levels =
+      jb::itch5::price_levels(book.worst_bid().first, book.best_bid().first);
+  auto sell_price_levels = jb::itch5::price_levels(
+      book.best_offer().first, book.worst_offer().first);
+  stats.sample(buy_price_levels + sell_price_levels);
 }
 
 } // anonymous namespace


### PR DESCRIPTION
The issue (#30) has more details, but basically the code was ignoring levels with no active orders in the computation of how many levels would be required to represent the book with a simple array.
