### PR TITLE
array_based_order_book :: leftovers

### DIFF
--- a/jb/itch5/array_based_order_book.cpp
+++ b/jb/itch5/array_based_order_book.cpp
@@ -5,6 +5,34 @@
 namespace jb {
 namespace itch5 {
 
+namespace defaults {
+
+#ifndef JB_ARRAY_DEFAULTS_max_size
+#define JB_ARRAY_DEFAULTS_max_size 10000
+#endif
+std::size_t const max_size = JB_ARRAY_DEFAULTS_max_size;
+
+} // namespace defaults
+
+array_based_order_book::config::config()
+    : max_size(
+          desc("max-size")
+              .help(
+                  "Configure the max size of a array based order book."
+                  " Only used when enable-array-based is set"),
+          this, defaults::max_size) {
+}
+
+/// Validate the configuration
+void array_based_order_book::config::validate() const {
+  if ((max_size() <= 0) or (max_size() > defaults::max_size)) {
+    std::ostringstream os;
+    os << "max-size must be > 0 and <=" << defaults::max_size
+       << ", value=" << max_size();
+    throw jb::usage(os.str(), 1);
+  }
+}
+
 /// check that parameters are valid
 void validate_add_order_params(int qty, price4_t px) {
   if (qty <= 0 or px >= max_price_field_value<price4_t>()) {
@@ -12,16 +40,6 @@ void validate_add_order_params(int qty, price4_t px) {
     os << "array_based_book_side::validate_add_order_params out of range."
        << " px=" << px << " qty=" << qty;
     throw jb::feed_error(os.str());
-  }
-}
-
-/// Validate the configuration
-void array_based_order_book::config::validate() const {
-  if ((max_size() <= 0) or (max_size() > defaults::Max_Size)) {
-    std::ostringstream os;
-    os << "max-size must be > 0 and <=" << defaults::Max_Size
-       << ", value=" << max_size();
-    throw jb::usage(os.str(), 1);
   }
 }
 

--- a/jb/itch5/array_based_order_book.cpp
+++ b/jb/itch5/array_based_order_book.cpp
@@ -1,4 +1,4 @@
-#include <jb/itch5/array_based_order_book.hpp>
+#include "jb/itch5/array_based_order_book.hpp"
 
 #include <sstream>
 

--- a/jb/itch5/array_based_order_book.cpp
+++ b/jb/itch5/array_based_order_book.cpp
@@ -1,7 +1,4 @@
-#include <jb/itch5/price_field.hpp>
-#include <jb/itch5/quote_defaults.hpp>
-#include <jb/feed_error.hpp>
-#include <sstream>
+#include <jb/itch5/array_based_order_book.hpp>
 
 namespace jb {
 namespace itch5 {
@@ -10,11 +7,20 @@ namespace itch5 {
 void validate_add_order_params(int qty, price4_t px) {
   if (qty <= 0 or px >= max_price_field_value<price4_t>()) {
     std::ostringstream os;
-    os << "array_based_order_book::add_order value(s) out of range."
+    os << "array_based_order_book::validate_add_order_params out of range."
        << " px=" << px << " qty=" << qty;
     throw jb::feed_error(os.str());
   }
 }
 
+/// Validate the configuration
+void array_based_order_book::config::validate() const {
+  if ((max_size() <= 0) or (max_size() > defaults::Max_Size)) {
+    std::ostringstream os;
+    os << "max-size must be > 0 and <=" << defaults::Max_Size
+       << ", value=" << max_size();
+    throw jb::usage(os.str(), 1);
+  }
+}
 } // namespace itch5
 } // namespace jb

--- a/jb/itch5/array_based_order_book.cpp
+++ b/jb/itch5/array_based_order_book.cpp
@@ -26,7 +26,7 @@ void array_based_order_book::config::validate() const {
 }
 
 /// handle exception with tk_begin_top_, px, and qty
-void handle_exception(
+void raise_exception(
     std::string str, std::size_t tk_begin_top, price4_t px, int qty) {
   std::ostringstream os;
   os << str << " tk_begin_top_=" << tk_begin_top << " px=" << px
@@ -35,7 +35,7 @@ void handle_exception(
 }
 
 /// handle exception with relative inside and px relative position
-void handle_exception(
+void raise_exception(
     std::string str, std::size_t tk_begin_top, std::size_t tk_inside,
     std::size_t rel_px, price4_t px, int qty) {
   std::ostringstream os;

--- a/jb/itch5/array_based_order_book.cpp
+++ b/jb/itch5/array_based_order_book.cpp
@@ -1,5 +1,7 @@
 #include <jb/itch5/array_based_order_book.hpp>
 
+#include <sstream>
+
 namespace jb {
 namespace itch5 {
 
@@ -7,7 +9,7 @@ namespace itch5 {
 void validate_add_order_params(int qty, price4_t px) {
   if (qty <= 0 or px >= max_price_field_value<price4_t>()) {
     std::ostringstream os;
-    os << "array_based_order_book::validate_add_order_params out of range."
+    os << "array_based_book_side::validate_add_order_params out of range."
        << " px=" << px << " qty=" << qty;
     throw jb::feed_error(os.str());
   }
@@ -21,6 +23,25 @@ void array_based_order_book::config::validate() const {
        << ", value=" << max_size();
     throw jb::usage(os.str(), 1);
   }
+}
+
+/// handle exception with tk_begin_top_, px, and qty
+void handle_exception(
+    std::string str, std::size_t tk_begin_top, price4_t px, int qty) {
+  std::ostringstream os;
+  os << str << " tk_begin_top_=" << tk_begin_top << " px=" << px
+     << " qty=" << qty;
+  throw jb::feed_error(os.str());
+}
+
+/// handle exception with relative inside and px relative position
+void handle_exception(
+    std::string str, std::size_t tk_begin_top, std::size_t tk_inside,
+    std::size_t rel_px, price4_t px, int qty) {
+  std::ostringstream os;
+  os << str << " tk_begin_top_=" << tk_begin_top << " tk_inside_" << tk_inside
+     << " px relative position " << rel_px << " px=" << px << " qty=" << qty;
+  throw jb::feed_error(os.str());
 }
 } // namespace itch5
 } // namespace jb

--- a/jb/itch5/array_based_order_book.hpp
+++ b/jb/itch5/array_based_order_book.hpp
@@ -28,8 +28,7 @@ namespace defaults {
 #ifndef JB_ARRAY_DEFAULTS_max_size
 #define JB_ARRAY_DEFAULTS_max_size 10000
 #endif
-
-std::size_t max_size = JB_ARRAY_DEFAULTS_max_size;
+static std::size_t Max_Size = JB_ARRAY_DEFAULTS_max_size;
 
 } // namespace defaults
 
@@ -60,20 +59,13 @@ public:
                 .help(
                     "Configure the max size of a array based order book."
                     " Only used when enable-array-based is set"),
-            this, jb::itch5::defaults::max_size) {
+            this, jb::itch5::defaults::Max_Size) {
   }
 
   config_object_constructors(config);
 
   /// Validate the configuration
-  void validate() const override {
-    if ((max_size() <= 0) or (max_size() > jb::itch5::defaults::max_size)) {
-      std::ostringstream os;
-      os << "max-size must be > 0 and <=" << jb::itch5::defaults::max_size
-         << ", value=" << max_size();
-      throw jb::usage(os.str(), 1);
-    }
-  }
+  void validate() const override;
 
   jb::config_attribute<config, std::size_t> max_size;
 };
@@ -155,17 +147,16 @@ public:
 
   /**
    * Add a price and quantity to the side order book.
+   * - if px is worse than the px_begin_top_ then px goes to bottom_levels
+   * - if px is better than the inside then changes inside, redefines limits
+   * if needed (moving the tail to bottom_levels if any)
+   * - finally, updates qty at the relative(px)
    *
    * @param px the price of the new order
    * @param qty the quantity of the new order
    * @returns true if the inside changed
    *
    * @throw feed_error px out of valid range, or qty <= 0
-   *
-   * - if px is worse than the px_begin_top_ then px goes to bottom_levels
-   * - if px is better than the inside then changes inside, redefines limits
-   * if needed (moving the tail to bottom_levels if any)
-   * - finally, updates qty at the relative(px)
    */
   bool add_order(price4_t px, int qty) {
     validate_add_order_params(qty, px);

--- a/jb/itch5/array_based_order_book.hpp
+++ b/jb/itch5/array_based_order_book.hpp
@@ -13,7 +13,6 @@
 #include <cmath>
 #include <functional>
 #include <map>
-#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -22,6 +21,9 @@ namespace itch5 {
 
 // forward declaration of
 void validate_add_order_params(int, price4_t px = price4_t(0));
+void handle_exception(std::string, std::size_t, price4_t, int);
+void handle_exception(
+    std::string, std::size_t, std::size_t, std::size_t, price4_t, int);
 
 namespace defaults {
 
@@ -223,12 +225,10 @@ public:
     if (side<compare_t>::better_level(tk_begin_top_, tk_px)) {
       auto price_it = bottom_levels_.find(tk_px);
       if (price_it == bottom_levels_.end()) {
-        std::ostringstream os;
-        os << "array_based_order_book::reduce_order."
-           << " Trying to reduce a non-existing bottom_levels_ price."
-           << " tk_begin_top_=" << tk_begin_top_ << " px=" << px
-           << " qty=" << qty;
-        throw jb::feed_error(os.str());
+        handle_exception(
+            "array_based_book_side::reduce_order."
+            " Trying to reduce non-existing bottom_levels_price.",
+            tk_begin_top_, px, qty);
       }
       // ... reduce the quantity ...
       price_it->second -= qty;
@@ -246,25 +246,20 @@ public:
 
     // handles the top_levels_ price
     if (side<compare_t>::better_level(tk_px, tk_inside_)) {
-      std::ostringstream os;
-      os << "array_based_order_book::reduce_order."
-         << " Trying to reduce a non-existing top_levels_ price"
-         << " (better px_inside)."
-         << " tk_begin_top_=" << tk_begin_top_ << " tk_inside_=" << tk_inside_
-         << " tk_end_top_=" << tk_end_top_ << " px=" << px << " qty=" << qty;
-      throw jb::feed_error(os.str());
+      handle_exception(
+          "array_based_book_side::reduce_order."
+          " Trying to reduce a non-existing top_levels_ price"
+          " (better px_inside).",
+          tk_begin_top_, px, qty);
     }
     // get px relative position
     auto rel_px = side<compare_t>::level_to_relative(tk_begin_top_, tk_px);
     if (top_levels_.at(rel_px) == 0) {
-      std::ostringstream os;
-      os << "array_based_order_book::reduce_order."
-         << " Trying to reduce a non-existing top_levels_ price"
-         << " (top_levels_[rel_px] == 0)."
-         << " tk_begin_top_=" << tk_begin_top_ << " tk_inside_=" << tk_inside_
-         << " tk_end_top_=" << tk_end_top_ << " px relative position=" << rel_px
-         << " px=" << px << " qty=" << qty;
-      throw jb::feed_error(os.str());
+      handle_exception(
+          "array_based_book_side::reduce_order."
+          " Trying to reduce a non-existing top_levels_ price"
+          " (top_levels_[rel_px] == 0).",
+          tk_begin_top_, tk_inside_, rel_px, px, qty);
     }
 
     // ... reduce the quantity ...

--- a/jb/itch5/array_based_order_book.hpp
+++ b/jb/itch5/array_based_order_book.hpp
@@ -21,8 +21,8 @@ namespace itch5 {
 
 // forward declaration of
 void validate_add_order_params(int, price4_t px = price4_t(0));
-void handle_exception(std::string, std::size_t, price4_t, int);
-void handle_exception(
+void raise_exception(std::string, std::size_t, price4_t, int);
+void raise_exception(
     std::string, std::size_t, std::size_t, std::size_t, price4_t, int);
 
 namespace defaults {
@@ -225,7 +225,7 @@ public:
     if (side<compare_t>::better_level(tk_begin_top_, tk_px)) {
       auto price_it = bottom_levels_.find(tk_px);
       if (price_it == bottom_levels_.end()) {
-        handle_exception(
+        raise_exception(
             "array_based_book_side::reduce_order."
             " Trying to reduce non-existing bottom_levels_price.",
             tk_begin_top_, px, qty);
@@ -246,7 +246,7 @@ public:
 
     // handles the top_levels_ price
     if (side<compare_t>::better_level(tk_px, tk_inside_)) {
-      handle_exception(
+      raise_exception(
           "array_based_book_side::reduce_order."
           " Trying to reduce a non-existing top_levels_ price"
           " (better px_inside).",
@@ -255,7 +255,7 @@ public:
     // get px relative position
     auto rel_px = side<compare_t>::level_to_relative(tk_begin_top_, tk_px);
     if (top_levels_.at(rel_px) == 0) {
-      handle_exception(
+      raise_exception(
           "array_based_book_side::reduce_order."
           " Trying to reduce a non-existing top_levels_ price"
           " (top_levels_[rel_px] == 0).",

--- a/jb/itch5/array_based_order_book.hpp
+++ b/jb/itch5/array_based_order_book.hpp
@@ -25,15 +25,6 @@ void raise_exception(std::string, std::size_t, price4_t, int);
 void raise_exception(
     std::string, std::size_t, std::size_t, std::size_t, price4_t, int);
 
-namespace defaults {
-
-#ifndef JB_ARRAY_DEFAULTS_max_size
-#define JB_ARRAY_DEFAULTS_max_size 10000
-#endif
-static std::size_t Max_Size = JB_ARRAY_DEFAULTS_max_size;
-
-} // namespace defaults
-
 template <typename compare_t>
 class array_based_book_side;
 
@@ -55,15 +46,7 @@ struct array_based_order_book {
  */
 class array_based_order_book::config : public jb::config_object {
 public:
-  config()
-      : max_size(
-            desc("max-size")
-                .help(
-                    "Configure the max size of a array based order book."
-                    " Only used when enable-array-based is set"),
-            this, jb::itch5::defaults::Max_Size) {
-  }
-
+  config();
   config_object_constructors(config);
 
   /// Validate the configuration

--- a/jb/itch5/testing/ut_type_based_order_book.hpp
+++ b/jb/itch5/testing/ut_type_based_order_book.hpp
@@ -80,7 +80,7 @@ void test_side_type_errors(side_type& tested) {
       tested.reduce_order(price4_t(100000 + 2 * diff), 100), jb::feed_error);
 
   // ... reduce non existing order on an empty bottom levels
-  if (diff < 0) {
+  if (tested.is_ascending()) {
     // buy side
     // reduce an non-existing order below the low range, empty bottom...
     BOOST_CHECK_THROW(tested.reduce_order(price4_t(1000), 100), jb::feed_error);

--- a/jb/itch5/ut_array_based_order_book.cpp
+++ b/jb/itch5/ut_array_based_order_book.cpp
@@ -32,6 +32,8 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_errors) {
 /**
  * @test Verify that the buy side of array_based_order_book works as
  * expected.
+ * Test inside changes at the top levels, and one price moved from
+ * bottom to top to become the new inside.
  */
 BOOST_AUTO_TEST_CASE(array_based_order_book_buy) {
   using namespace jb::itch5;
@@ -60,7 +62,7 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_buy) {
   // .. and the book_depth should be incremented
   BOOST_CHECK_EQUAL(tested.count(), 2);
 
-  // ... add an order below the low limit 5 cents
+  // ... adding below the top_level_ low limit has not effect...
   r = tested.add_order(price4_t(500), 700);
   actual = tested.best_quote();
   BOOST_CHECK_EQUAL(actual.first, price4_t(100000));
@@ -78,20 +80,21 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_buy) {
   actual = tested.best_quote();
   BOOST_CHECK_EQUAL(actual.first, price4_t(100000));
   BOOST_CHECK_EQUAL(actual.second, 500);
+  // ... still change at the bid
   BOOST_CHECK_EQUAL(r, true);
   // .. and the book_depth should not be incremented
   BOOST_CHECK_EQUAL(tested.count(), 3);
 
-  // ... a better price changes both price (+1 ticks) and qty ...
+  // ... a better price changes both price and qty ...
   r = tested.add_order(price4_t(100100), 200);
   actual = tested.best_quote();
   BOOST_CHECK_EQUAL(actual.first, price4_t(100100));
   BOOST_CHECK_EQUAL(actual.second, 200);
-  BOOST_CHECK_EQUAL(r, true); // inside moves one tick up
+  BOOST_CHECK_EQUAL(r, true); // inside moves up
   // .. and the book_depth should be incremented
   BOOST_CHECK_EQUAL(tested.count(), 4);
 
-  // ... decrease below the bid has no effect ...
+  // ... decrease (400 out of 500) below the bid has no effect ...
   r = tested.reduce_order(price4_t(100000), 400);
   actual = tested.best_quote();
   BOOST_CHECK_EQUAL(actual.first, price4_t(100100));
@@ -101,6 +104,7 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_buy) {
   BOOST_CHECK_EQUAL(tested.count(), 4);
 
   // ... even when it is over the existing quantity ...
+  // reducing 200 out of 100, count should decrement ...
   r = tested.reduce_order(price4_t(100000), 200);
   actual = tested.best_quote();
   BOOST_CHECK_EQUAL(actual.first, price4_t(100100));
@@ -121,6 +125,8 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_buy) {
   // ... deleting the remaining price takes the book depth to 0
   r = tested.reduce_order(price4_t(99900), 300);
   actual = tested.best_quote();
+  // ... it moves one price from the bottom to the top
+  // and it is the new inside now...
   BOOST_CHECK_EQUAL(actual.first, price4_t(500));
   BOOST_CHECK_EQUAL(actual.second, 700);
   BOOST_CHECK_EQUAL(r, true);
@@ -138,6 +144,8 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_buy) {
 /**
  * @test Verity that the sell side of array_based_order_book works as
  * expected.
+ * Test inside changes at the top levels, and one price moved from
+ * bottom to top to become the new inside.
  */
 BOOST_AUTO_TEST_CASE(array_based_order_book_sell) {
   using namespace jb::itch5;
@@ -165,6 +173,20 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell) {
   // .. and the book_depth should be incremented
   BOOST_CHECK_EQUAL(tested.count(), 2);
 
+  // ... adding above the top_level_ low limit has not effect...
+  // but count is incremented...
+  r = tested.add_order(price4_t(1000000), 100);
+  actual = tested.best_quote();
+  BOOST_CHECK_EQUAL(actual.first, price4_t(100000));
+  BOOST_CHECK_EQUAL(actual.second, 100);
+  BOOST_CHECK_EQUAL(r, false);
+  // worst bid is now at the bottom_levels
+  actual = tested.worst_quote();
+  BOOST_CHECK_EQUAL(actual.first, price4_t(1000000));
+  BOOST_CHECK_EQUAL(actual.second, 100);
+  // .. and the book_depth should be incremented
+  BOOST_CHECK_EQUAL(tested.count(), 3);
+
   // ... update at the offer increases the qty ...
   r = tested.add_order(price4_t(100000), 400);
   actual = tested.best_quote();
@@ -173,7 +195,7 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell) {
   // handler should return true... it is an inside change
   BOOST_CHECK_EQUAL(r, true);
   // .. and the book_depth should not change
-  BOOST_CHECK_EQUAL(tested.count(), 2);
+  BOOST_CHECK_EQUAL(tested.count(), 3);
 
   // ... a better price changes both price and qty ...
   r = tested.add_order(price4_t(99900), 200);
@@ -182,25 +204,27 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell) {
   BOOST_CHECK_EQUAL(actual.second, 200);
   BOOST_CHECK_EQUAL(r, true);
   // .. and the book_depth should be incremented
-  BOOST_CHECK_EQUAL(tested.count(), 3);
+  BOOST_CHECK_EQUAL(tested.count(), 4);
 
   // ... decrease above the offer has no effect ...
+  // reduce 400 out of 500, so still same count
   r = tested.reduce_order(price4_t(100000), 400);
   actual = tested.best_quote();
   BOOST_CHECK_EQUAL(actual.first, price4_t(99900));
   BOOST_CHECK_EQUAL(actual.second, 200);
   BOOST_CHECK_EQUAL(r, false);
   // .. and the book_depth should not change
-  BOOST_CHECK_EQUAL(tested.count(), 3);
+  BOOST_CHECK_EQUAL(tested.count(), 4);
 
   // ... even when it is over the existing quantity ...
+  // but reduce the count
   r = tested.reduce_order(price4_t(100000), 200);
   actual = tested.best_quote();
   BOOST_CHECK_EQUAL(actual.first, price4_t(99900));
   BOOST_CHECK_EQUAL(actual.second, 200);
   BOOST_CHECK_EQUAL(r, false);
   // .. and the book_depth should be incremented
-  BOOST_CHECK_EQUAL(tested.count(), 2);
+  BOOST_CHECK_EQUAL(tested.count(), 3);
 
   // ... deleting the best offer uncovers the best price ...
   r = tested.reduce_order(price4_t(99900), 200);
@@ -209,10 +233,20 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell) {
   BOOST_CHECK_EQUAL(actual.second, 300);
   BOOST_CHECK_EQUAL(r, true);
   // .. and the book_depth should be incremented
-  BOOST_CHECK_EQUAL(tested.count(), 1);
+  BOOST_CHECK_EQUAL(tested.count(), 2);
 
   // ... deleting the remaining price takes the book depth to 0
   r = tested.reduce_order(price4_t(100100), 300);
+  actual = tested.best_quote();
+  BOOST_CHECK_EQUAL(actual.first, price4_t(1000000));
+  BOOST_CHECK_EQUAL(actual.second, 100);
+  // handler should return true
+  BOOST_CHECK_EQUAL(r, true);
+  // .. and the book_depth should be decremented
+  BOOST_CHECK_EQUAL(tested.count(), 1);
+
+  // ... deleting the remaining price takes the book depth to 0
+  r = tested.reduce_order(price4_t(1000000), 100);
   actual = tested.best_quote();
   BOOST_CHECK_EQUAL(actual.first, price4_t(200000UL * 10000));
   BOOST_CHECK_EQUAL(actual.second, 0);
@@ -225,6 +259,9 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell) {
 /**
  * @test Verify that the buy side of array_based_order_book works as
  * expected.
+ * Works adding and removing prices at the limit of top level range
+ * to verify move form and to the bottom level work as expected on those
+ * border cases.
  */
 BOOST_AUTO_TEST_CASE(array_based_order_book_buy_range) {
   using namespace jb::itch5;
@@ -233,17 +270,24 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_buy_range) {
   array_based_order_book::buys_t tested(
       array_based_order_book::config().max_size(2 * ticks));
 
-  // build a book around $50.00
+  // build a book around $50.00 (limits built around when
+  // first price is added...
+  // top end limit is now 200 * ticks...
   auto rs = tested.add_order(price4_t(100 * ticks), 100);
   BOOST_CHECK_EQUAL(rs, true);
+
+  // now add one better price, inside changes...
   rs = tested.add_order(price4_t(100 * ticks + 100), 100);
   BOOST_CHECK_EQUAL(rs, true);
+
+  // and 3 prices(*) down, nothing changes, but the count..
   rs = tested.add_order(price4_t(100 * ticks - 100), 100);
   BOOST_CHECK_EQUAL(rs, false);
   rs = tested.add_order(price4_t(100 * ticks - 200), 100);
   BOOST_CHECK_EQUAL(rs, false);
   rs = tested.add_order(price4_t(100 * ticks - 300), 100);
   BOOST_CHECK_EQUAL(rs, false);
+  BOOST_CHECK_EQUAL(tested.count(), 5);
 
   // change the inside 2 ticks below the limit
   rs = tested.add_order(price4_t(200 * ticks - 200), 100);
@@ -254,40 +298,43 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_buy_range) {
   BOOST_CHECK_EQUAL(rs, true);
 
   // change the inside right at the limit (therefore out)
+  // new limits are now 100*tick and 300*tick
+  // the 3 prices (*) are now at the bottom levels (test move_to_bottom)
   rs = tested.add_order(price4_t(200 * ticks), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
   // change the inside far above the limit
+  // all the prices, but the new inside, are now at the bottom levels
+  // this is in preration to test move_from_botom...
   rs = tested.add_order(price4_t(1600 * ticks), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
-  // add new price
+  // add new price, this is the second best price now....
   rs = tested.add_order(price4_t(200 * ticks + 100), 100);
   BOOST_CHECK_EQUAL(rs, false);
 
   // remove that far above price
-  // new inside is price4_t(200*ticks + 100)
+  // new inside is price4_t(200*ticks + 100, previous one)...
+  // prices were moved_from_bottom, some were not.,,
   rs = tested.reduce_order(price4_t(1600 * ticks), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
+  // now remove prices around 200*ticks~... should not move prices...
   // remove the inside
   rs = tested.reduce_order(price4_t(200 * ticks + 100), 100);
   BOOST_CHECK_EQUAL(rs, true);
-
   // remove the inside
   rs = tested.reduce_order(price4_t(200 * ticks), 100);
   BOOST_CHECK_EQUAL(rs, true);
-
   // remove the inside
   rs = tested.reduce_order(price4_t(200 * ticks - 100), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
-  // remove the inside, range does not change...
-  // new inside is right at the bottom of the range
+  // new inside is right at the bottom of the range...
   rs = tested.reduce_order(price4_t(200 * ticks - 200), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
-  // remove the inside, range changes...
+  // remove the inside, prices are move from the bottom
   rs = tested.reduce_order(price4_t(100 * ticks + 100), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
@@ -300,11 +347,15 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_buy_range) {
   BOOST_CHECK_EQUAL(rs, true);
   rs = tested.reduce_order(price4_t(100 * ticks - 300), 100);
   BOOST_CHECK_EQUAL(rs, true);
+  BOOST_CHECK_EQUAL(tested.count(), 0);
 }
 
 /**
  * @test Verify that the buy side of array_based_order_book works as
  * expected.
+ * Works adding and removing prices at the limit of top level range
+ * to verify move form and to the bottom level work as expected on those
+ * border cases.
  */
 BOOST_AUTO_TEST_CASE(array_based_order_book_sell_range) {
   using namespace jb::itch5;
@@ -314,24 +365,29 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell_range) {
       array_based_order_book::config().max_size(2 * ticks));
 
   BOOST_CHECK_EQUAL(tested.count(), 0);
-  // build a book around 10*ticks
+  // build a book around 1000*ticks
+  // top levels range is 900*ticks by 1100*ticks
   auto rs = tested.add_order(price4_t(1000 * ticks), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
+  // new inside, same range...
   rs = tested.add_order(price4_t(1000 * ticks - 100), 100);
   BOOST_CHECK_EQUAL(rs, true);
+  // a 3 prices(*) to test the move_to_bottom trigger...
   rs = tested.add_order(price4_t(1000 * ticks + 100), 100);
   BOOST_CHECK_EQUAL(rs, false);
   rs = tested.add_order(price4_t(1000 * ticks + 200), 100);
   BOOST_CHECK_EQUAL(rs, false);
   rs = tested.add_order(price4_t(1000 * ticks + 300), 100);
   BOOST_CHECK_EQUAL(rs, false);
+  BOOST_CHECK_EQUAL(tested.count(), 5);
 
   // change the inside right below the limit
   rs = tested.add_order(price4_t(900 * ticks + 100), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
-  // change the inside right at the limit (P_MAX is excluded)
+  // change the inside right at the limit
+  // ... limit is excluded so it triggers the move to bottom
   rs = tested.add_order(price4_t(900 * ticks), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
@@ -340,10 +396,12 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell_range) {
   BOOST_CHECK_EQUAL(rs, true);
 
   // change the inside far above the limit
+  // all prices move to bottom
   rs = tested.add_order(price4_t(100 * ticks), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
   // add a new price far below
+  // in preparation to test move from bottom
   rs = tested.add_order(price4_t(1000 * ticks - 300), 100);
   BOOST_CHECK_EQUAL(rs, false);
 
@@ -352,22 +410,23 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell_range) {
   BOOST_CHECK_EQUAL(rs, false);
 
   // remove the far above inside
+  // all prices (but 3 prices (*)) are move from bottom back to top levels...
   rs = tested.reduce_order(price4_t(100 * ticks), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
+  // now remove prices around 900*ticks to move the rest of the prices back...
   // removed the inside
   rs = tested.reduce_order(price4_t(900 * ticks - 200), 100);
   BOOST_CHECK_EQUAL(rs, true);
-
   // removed the inside
   rs = tested.reduce_order(price4_t(900 * ticks - 100), 100);
   BOOST_CHECK_EQUAL(rs, true);
-
   // removed the inside
   rs = tested.reduce_order(price4_t(900 * ticks), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
   // removed the inside, new inside right at the bottom of the range...
+  // the rest of prices are moved from the bottom
   rs = tested.reduce_order(price4_t(900 * ticks + 100), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
@@ -386,6 +445,7 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell_range) {
   BOOST_CHECK_EQUAL(rs, true);
   rs = tested.reduce_order(price4_t(1000 * ticks + 300), 100);
   BOOST_CHECK_EQUAL(rs, true);
+  BOOST_CHECK_EQUAL(tested.count(), 0);
 }
 
 /**
@@ -393,6 +453,9 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell_range) {
  * works as expected.
  * Test suite for prices below $1.00. A smaller tick offset is used to
  * facilitate the tests
+ * Works adding and removing prices at the limit of top level range
+ * to verify move form and to the bottom level work as expected on those
+ * border cases.
  */
 BOOST_AUTO_TEST_CASE(array_based_order_book_buy_small_tick) {
   using namespace jb::itch5;
@@ -401,6 +464,7 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_buy_small_tick) {
       array_based_order_book::config().max_size(3000));
 
   // build a book around 15 cents
+  // top level range is 0c (included) by 30c (excluded)
   auto rs = tested.add_order(price4_t(1500), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
@@ -414,18 +478,23 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_buy_small_tick) {
   BOOST_CHECK_EQUAL(rs, false);
 
   // change the inside right below the limit
+  // no prices moved...
   rs = tested.add_order(price4_t(2998), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
   // change the inside right at the limit
+  // mo prices moved...
   rs = tested.add_order(price4_t(2999), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
   // change the inside right above the limit
+  // new  range is 15c by 45c
+  // .. prices below 15c are moved to the bottom...
   rs = tested.add_order(price4_t(3000), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
   // change the inside far above the limit
+  // all prices, but the new inside, are moved to the bottom
   rs = tested.add_order(price4_t(9999), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
@@ -434,23 +503,9 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_buy_small_tick) {
   BOOST_CHECK_EQUAL(rs, false);
 
   // remove the far above inside
+  // new top levels range is 15.01c by 45.01c
+  // so some prices are moved back from bottom levels...
   rs = tested.reduce_order(price4_t(9999), 100);
-  BOOST_CHECK_EQUAL(rs, true);
-
-  // change the inside far above the limit
-  rs = tested.add_order(price4_t(10000), 100);
-  BOOST_CHECK_EQUAL(rs, true);
-
-  // change the inside far above the limit
-  rs = tested.add_order(price4_t(10200), 100);
-  BOOST_CHECK_EQUAL(rs, true);
-
-  // remove the far above inside
-  rs = tested.reduce_order(price4_t(10000), 100);
-  BOOST_CHECK_EQUAL(rs, false);
-
-  // remove the far above inside
-  rs = tested.reduce_order(price4_t(10200), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
   // remove price to test
@@ -477,6 +532,7 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_buy_small_tick) {
   BOOST_CHECK_EQUAL(rs, true);
   rs = tested.reduce_order(price4_t(1498), 100);
   BOOST_CHECK_EQUAL(rs, true);
+  BOOST_CHECK_EQUAL(tested.count(), 0);
 }
 
 /**
@@ -484,6 +540,9 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_buy_small_tick) {
  * works as expected.
  * Test suite for prices below $1.00. A smaller tick offset is used to
  * facilitate the tests
+ * Works adding and removing prices at the limit of top level range
+ * to verify move form and to the bottom level work as expected on those
+ * border cases.
  */
 BOOST_AUTO_TEST_CASE(array_based_order_book_sell_small_tick) {
   using namespace jb::itch5;
@@ -492,6 +551,7 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell_small_tick) {
       array_based_order_book::config().max_size(3000));
 
   // build a book around 75 cents
+  // top levels range is 60c by 90c
   auto rs = tested.add_order(price4_t(7500), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
@@ -513,6 +573,7 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell_small_tick) {
   BOOST_CHECK_EQUAL(rs, true);
 
   // change the inside far above the limit
+  // move all prices, but the new inside, to the bottom levels...
   rs = tested.add_order(price4_t(989), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
@@ -521,6 +582,7 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell_small_tick) {
   BOOST_CHECK_EQUAL(rs, false);
 
   // remove the far above inside
+  // prices are move back from the bottom...
   rs = tested.reduce_order(price4_t(989), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
@@ -531,6 +593,7 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell_small_tick) {
   BOOST_CHECK_EQUAL(rs, false);
 
   // remove the inside
+  // the rest of the prices is moved back to the top levels
   rs = tested.reduce_order(price4_t(5998), 100);
   BOOST_CHECK_EQUAL(rs, true);
 
@@ -546,6 +609,7 @@ BOOST_AUTO_TEST_CASE(array_based_order_book_sell_small_tick) {
   BOOST_CHECK_EQUAL(rs, true);
   rs = tested.reduce_order(price4_t(7502), 100);
   BOOST_CHECK_EQUAL(rs, true);
+  BOOST_CHECK_EQUAL(tested.count(), 0);
 }
 
 /**


### PR DESCRIPTION
The following changes were left on my branch before the last pull request was accepted.

I think it deserves to take a look to see if we want them integrated. Let me know your thoughts.

Move config::validate to a cpp file.
Fix minor usage of is_ascending on UT.
Improve UT comments.
Fix misleading exception messages.
Move ssteam out of array_based_order_book.hpp to *.cpp