### PR TITLE
Fix #76, consistently use max_differences_printed.

### DIFF
--- a/jb/testing/check_array_close_enough.hpp
+++ b/jb/testing/check_array_close_enough.hpp
@@ -12,17 +12,29 @@ namespace testing {
  *
  * Given two collections of floating point or complex numbers find the
  * differences and report them via Boost.Test functions.
+ *
+ * @param size the size of the vector / collection
+ * @param actual the actual values observed in the test
+ * @param expected the values expected by the test
+ * @param tol the error accepted by the test, or more precisely, the
+ *   test will tolerate up to tol*epsilon relative error.
+ * @param max_differences_printed how many differences will be printed
+ *   out in full detail, some of the vectors are large and printing
+ *   all the differences can be overwhelming.
+ *
+ * @returns the number of errors detected.
  */
 template <typename value_type>
-void check_array_close_enough(
+int check_array_close_enough(
     std::size_t size, value_type const* actual, value_type const* expected,
-    int tol = 1, int max_differences = JB_TESTING_MAX_DIFFERENCES) {
+    int tol = 1,
+    int max_differences_printed = JB_TESTING_MAX_DIFFERENCES_PRINTED) {
   int count = 0;
   for (std::size_t i = 0; i != size; ++i) {
     if (close_enough(actual[i], expected[i], tol)) {
       continue;
     }
-    if (++count <= max_differences) {
+    if (++count <= max_differences_printed) {
       BOOST_CHECK_MESSAGE(
           close_enough(actual[i], expected[i], tol),
           "in item i=" << i << " difference higher than tolerance=" << tol
@@ -31,6 +43,7 @@ void check_array_close_enough(
     }
   }
   BOOST_CHECK_MESSAGE(count == 0, "found " << count << " differences");
+  return count;
 }
 
 } // namespace testing

--- a/jb/testing/check_complex_close_enough.hpp
+++ b/jb/testing/check_complex_close_enough.hpp
@@ -102,9 +102,9 @@ value_type format(value_type t) {
   return t;
 }
 
-#ifndef JB_TESTING_MAX_DIFFERENCES
-#define JB_TESTING_MAX_DIFFERENCES 8
-#endif // JB_TESTING_MAX_DIFFERENCES
+#ifndef JB_TESTING_MAX_DIFFERENCES_PRINTED
+#define JB_TESTING_MAX_DIFFERENCES_PRINTED 8
+#endif // JB_TESTING_MAX_DIFFERENCES_PRINTED
 
 } // namespace testing
 } // namespace jb

--- a/jb/testing/check_multi_array_close_enough.hpp
+++ b/jb/testing/check_multi_array_close_enough.hpp
@@ -13,20 +13,28 @@ struct check_multi_array_close_enough_helper;
 /**
  * Report (using Boost.Test functions) any differences between the
  * elements in @a actual vs. @a expected, when the dimensionality is 1.
- *
- * Given two collections of floating point or complex numbers find the
- * differences and report them via Boost.Test functions.
  */
 template <typename multi_array>
 struct check_multi_array_close_enough_helper<multi_array, 1> {
+  /**
+   * Given two 1-dimensional multi-arrays of floating point or complex
+   * numbers find the differences and report them via Boost.Test functions.
+   *
+   * @param actual the actual values observed in the test
+   * @param expected the values expected by the test
+   * @param tol the error accepted by the test, or more precisely, the
+   *   test will tolerate up to tol*epsilon relative error.
+   * @param max_differences_printed how many differences will be printed
+   *   out in full detail, some of the vectors are large and printing
+   *   all the differences can be overwhelming.
+   *
+   * @returns the number of errors detected.
+   */
   static int check(
       multi_array const& actual, multi_array const& expected, int tol,
-      int max_differences) {
-    if (max_differences < 0) {
-      return 0;
-    }
-
-    return check_vector_close_enough(actual, expected, tol, max_differences);
+      int max_differences_printed) {
+    return check_vector_close_enough(
+        actual, expected, tol, max_differences_printed);
   }
 };
 
@@ -36,6 +44,20 @@ struct check_multi_array_close_enough_helper<multi_array, 1> {
  */
 template <typename multi_array>
 struct check_multi_array_close_enough_helper<multi_array, 0> {
+  /**
+   * Given two 0-dimensional multi-arrays of floating point or complex
+   * numbers find the differences and report them via Boost.Test functions.
+   *
+   * @param actual the actual values observed in the test
+   * @param expected the values expected by the test
+   * @param tol the error accepted by the test, or more precisely, the
+   *   test will tolerate up to tol*epsilon relative error.
+   * @param max_differences_printed how many differences will be printed
+   *   out in full detail, some of the vectors are large and printing
+   *   all the differences can be overwhelming.
+   *
+   * @returns the number of errors detected.
+   */
   static int check(
       multi_array const& actual, multi_array const& expected, int tol,
       int max_differences) {
@@ -47,25 +69,33 @@ struct check_multi_array_close_enough_helper<multi_array, 0> {
  * Report (using Boost.Test functions) any differences between the
  * elements in @a actual vs. @a expected, when the dimensionality of
  * the arrays is known.
- *
- * Given two collections of floating point or complex numbers find the
- * differences and report them via Boost.Test functions.
  */
 template <typename multi_array, std::size_t K>
 struct check_multi_array_close_enough_helper {
+  /**
+   * Given two K-dimensional multi-arrays of floating point or complex
+   * numbers find the differences and report them via Boost.Test functions.
+   *
+   * @param actual the actual values observed in the test
+   * @param expected the values expected by the test
+   * @param tol the error accepted by the test, or more precisely, the
+   *   test will tolerate up to tol*epsilon relative error.
+   * @param max_differences_printed how many differences will be printed
+   *   out in full detail, some of the vectors are large and printing
+   *   all the differences can be overwhelming.
+   *
+   * @returns the number of errors detected.
+   */
   static int check(
       multi_array const& actual, multi_array const& expected, int tol,
-      int max_differences) {
-    if (max_differences < 0) {
-      return 0;
-    }
-
+      int max_differences_printed) {
     int mismatches = 0;
     for (typename multi_array::size_type i = 0; i != actual.size(); ++i) {
       typedef typename multi_array::value_type value_type;
       mismatches +=
           check_multi_array_close_enough_helper<value_type, K - 1>::check(
-              actual[i], expected[i], tol, max_differences - mismatches);
+              actual[i], expected[i], tol,
+              max_differences_printed - mismatches);
     }
     return mismatches;
   }
@@ -77,14 +107,24 @@ struct check_multi_array_close_enough_helper {
  *
  * Given two collections of floating point or complex numbers find the
  * differences and report them via Boost.Test functions.
+ *
+ * @param actual the actual values observed in the test
+ * @param expected the values expected by the test
+ * @param tol the error accepted by the test, or more precisely, the
+ *   test will tolerate up to tol*epsilon relative error.
+ * @param max_differences_printed how many differences will be printed
+ *   out in full detail, some of the vectors are large and printing
+ *   all the differences can be overwhelming.
+ *
+ * @returns the number of errors detected.
  */
 template <typename multi_array>
 int check_multi_array_close_enough(
     multi_array const& actual, multi_array const& expected, int tol = 1,
-    int max_differences = JB_TESTING_MAX_DIFFERENCES) {
+    int max_differences_printed = JB_TESTING_MAX_DIFFERENCES_PRINTED) {
   return check_multi_array_close_enough_helper<multi_array,
                                                multi_array::dimensionality>::
-      check(actual, expected, tol, max_differences);
+      check(actual, expected, tol, max_differences_printed);
 }
 
 } // namespace testing

--- a/jb/testing/check_vector_close_enough.hpp
+++ b/jb/testing/check_vector_close_enough.hpp
@@ -12,14 +12,22 @@ namespace testing {
  *
  * Given two collections of floating point or complex numbers find the
  * differences and report them via Boost.Test functions.
+ *
+ * @param size the size of the vector / collection
+ * @param actual the actual values observed in the test
+ * @param expected the values expected by the test
+ * @param tol the error accepted by the test, or more precisely, the
+ *   test will tolerate up to tol*epsilon relative error.
+ * @param max_differences_printed how many differences will be printed
+ *   out in full detail, some of the vectors are large and printing
+ *   all the differences can be overwhelming.
+ *
+ * @returns the number of errors detected.
  */
 template <typename vector>
 int check_vector_close_enough(
     vector const& actual, vector const& expected, int tol = 1,
-    int max_differences = JB_TESTING_MAX_DIFFERENCES) {
-  if (max_differences <= 0) {
-    return 0;
-  }
+    int max_differences_printed = JB_TESTING_MAX_DIFFERENCES_PRINTED) {
   BOOST_CHECK_EQUAL(actual.size(), expected.size());
   if (actual.size() != expected.size()) {
     return static_cast<int>(std::max(actual.size(), expected.size()));
@@ -30,15 +38,15 @@ int check_vector_close_enough(
     if (close_enough(actual[i], expected[i], tol)) {
       continue;
     }
-    BOOST_CHECK_MESSAGE(
-        close_enough(actual[i], expected[i], tol),
-        "in item i=" << i << " difference higher than tolerance=" << tol
-                     << ", actual[i]=" << actual[i]
-                     << ", expected[i]=" << expected[i]);
-    if (++count > max_differences) {
-      return count;
+    if (++count <= max_differences_printed) {
+      BOOST_CHECK_MESSAGE(
+          close_enough(actual[i], expected[i], tol),
+          "in item i=" << i << " difference higher than tolerance=" << tol
+                       << ", actual[i]=" << actual[i]
+                       << ", expected[i]=" << expected[i]);
     }
   }
+  BOOST_CHECK_MESSAGE(count == 0, "found " << count << " differences");
   return count;
 }
 


### PR DESCRIPTION
Also improved the documentation of the
check_*_close_enough() family of functions.