### PR TITLE
Really fix #94

### DIFF
--- a/docker/dev/runvariant.sh
+++ b/docker/dev/runvariant.sh
@@ -49,6 +49,7 @@ VOLUME /home/\$user/jaybeams
 WORKDIR /root
 RUN useradd -m -u \$uid \$user
 RUN echo \$user ALL=NOPASSWD: ALL >>/etc/sudoers
+RUN chown \$user /home/\$user
 
 USER \$user
 WORKDIR /home/\$user/jaybeams


### PR DESCRIPTION
Fix the container created by runvariant.sh.  It was not possible to run unit tests that used the Portable Computing Library (pocl) implementation of OpenCL.
