### PR TITLE
Add benchmarks and driver scripts to install targets

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -92,6 +92,10 @@ benchmarks = \
   jb/bm_clocks \
   jb/itch5/bm_order_book
 
+bin_SCRIPTS = \
+  tools/benchmark_common.sh \
+  jb/itch5/bm_order_book_generate.sh
+
 examples = \
   examples/configuration
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,12 +1,10 @@
 # JayBeams uses a non-recursive make, this is the only Makefile.
 
-instdir = $(prefix)/lib
+instdir = $(prefix)
 
-inst_LIBRARIES = \
+lib_LIBRARIES = \
   jb/libjb.a \
-  jb/libjb_itch5.a
-
-noinst_LIBRARIES = \
+  jb/libjb_itch5.a \
   jb/libjb_testing.a \
   jb/libjb_itch5_testing.a
 
@@ -95,7 +93,9 @@ benchmarks = \
   jb/itch5/bm_order_book
 
 examples = \
-  examples/configuration \
+  examples/configuration
+
+bin_PROGRAMS = $(benchmarks) \
   tools/itch5bookdepth \
   tools/itch5eventdepth \
   tools/itch5inside \
@@ -105,7 +105,7 @@ examples = \
   tools/mold2inside \
   tools/moldheartbeat
 
-noinst_PROGRAMS = $(examples) $(benchmarks) \
+noinst_PROGRAMS = $(examples) \
   jb/testing/check_mt19937_initializer \
   jb/testing/check_random_device
 
@@ -199,7 +199,7 @@ endif !FOUND_CLANG_FORMAT
 ################################################################
 
 if USE_FFTW3
-inst_LIBRARIES += jb/libjb_fftw.a
+lib_LIBRARIES += jb/libjb_fftw.a
 unit_tests += jb/fftw/ut_aligned_multi_array \
   jb/fftw/ut_allocator \
   jb/fftw/ut_cast_multi_array \
@@ -296,7 +296,7 @@ jb_libjb_testing_a_SOURCES = \
   jb/testing/microbenchmark_base.cpp \
   jb/testing/microbenchmark_config.cpp
 
-jb_libjb_testing_a_HEADERS = \
+nobase_jb_libjb_testing_a_HEADERS = \
   jb/testing/check_close_enough.hpp \
   jb/testing/create_square_timeseries.hpp \
   jb/testing/create_triangle_timeseries.hpp \
@@ -334,7 +334,7 @@ jb_libjb_itch5_testing_adir = $(includedir)
 jb_libjb_itch5_testing_a_SOURCES = \
   jb/itch5/testing/data.cpp \
   jb/itch5/testing/messages.cpp
-jb_libjb_itch5_testing_a_HEADERS = \
+nobase_jb_libjb_itch5_testing_a_HEADERS = \
   jb/itch5/testing/data.hpp \
   jb/itch5/testing/messages.hpp
 
@@ -343,8 +343,6 @@ jb_libjb_itch5_testing_a_HEADERS = \
 ################################################################
 
 jb_libjb_itch5_adir = $(includedir)
-nobase_jb_libjb_itch5_a_HEADERS =
-
 jb_libjb_itch5_a_SOURCES = \
   jb/itch5/add_order_message.cpp \
   jb/itch5/add_order_mpid_message.cpp \
@@ -375,7 +373,7 @@ jb_libjb_itch5_a_SOURCES = \
   jb/itch5/timestamp.cpp \
   jb/itch5/trade_message.cpp
 
-jb_libjb_itch5_a_HEADERS = \
+nobase_jb_libjb_itch5_a_HEADERS = \
   jb/itch5/add_order_message.hpp \
   jb/itch5/add_order_mpid_message.hpp \
   jb/itch5/array_based_order_book.hpp \
@@ -435,7 +433,7 @@ jb_libjb_itch5_a_HEADERS = \
 jb_libjb_fftw_adir = $(includedir)
 jb_libjb_fftw_a_SOURCES = \
   jb/fftw/plan.cpp
-jb_libjb_fftw_a_HEADERS = \
+nobase_jb_libjb_fftw_a_HEADERS = \
   jb/fftw/aligned_multi_array.hpp \
   jb/fftw/aligned_vector.hpp \
   jb/fftw/allocator.hpp \
@@ -447,12 +445,12 @@ jb_libjb_fftw_a_HEADERS = \
   jb/fftw/traits.hpp
 
 ################################################################
-# jb/libjb_fftw.a
+# jb/libjb_tde.a
 ################################################################
 
 jb_libjb_tde_adir = $(includedir)
 jb_libjb_tde_a_SOURCES =
-jb_libjb_tde_a_HEADERS =
+nobase_jb_libjb_tde_a_HEADERS =
 
 ################################################################
 # examples
@@ -688,7 +686,7 @@ jb_fftw_bm_time_delay_estimator_LDFLAGS = \
 ################################################################
 if HAVE_OPENCL
 
-inst_LIBRARIES += jb/libjb_opencl.a
+lib_LIBRARIES += jb/libjb_opencl.a
 jb_opencl_unit_tests = \
   jb/opencl/ut_build_simple_kernel \
   jb/opencl/ut_copy_to_host_async \
@@ -707,7 +705,7 @@ jb_ut_opencl_ldadd = \
 jb_ut_opencl_ldflags = \
   $(OPENCL_LDFLAGS)
 
-inst_LIBRARIES += jb/libjb_clfft.a
+lib_LIBRARIES += jb/libjb_clfft.a
 jb_clfft_unit_tests = \
   jb/clfft/ut_error \
   jb/clfft/ut_plan
@@ -721,7 +719,7 @@ jb_ut_clfft_ldflags = \
   $(CLFFT_LDFLAGS) \
   $(jb_ut_opencl_ldflags)
 
-inst_LIBRARIES += jb/libjb_tde.a
+lib_LIBRARIES += jb/libjb_tde.a
 jb_tde_unit_tests = \
   jb/tde/ut_conjugate_and_multiply \
   jb/tde/ut_generic_reduce \
@@ -744,7 +742,9 @@ check_PROGRAMS += \
   $(jb_tde_unit_tests)
 
 noinst_PROGRAMS += \
-  $(jb_opencl_examples) \
+  $(jb_opencl_examples)
+
+bin_PROGRAMS += \
   $(jb_opencl_benchmarks) \
   $(jb_clfft_benchmarks) \
   $(jb_tde_benchmarks)
@@ -758,7 +758,7 @@ jb_libjb_opencl_a_SOURCES = \
   jb/opencl/build_simple_kernel.cpp \
   jb/opencl/config.cpp \
   jb/opencl/device_selector.cpp
-jb_libjb_opencl_a_HEADERS = \
+nobase_jb_libjb_opencl_a_HEADERS = \
   jb/opencl/build_simple_kernel.hpp \
   jb/opencl/config.hpp \
   jb/opencl/device_selector.hpp
@@ -802,7 +802,7 @@ jb_libjb_clfft_adir = $(includedir)
 jb_libjb_clfft_a_SOURCES = \
   jb/clfft/error.cpp \
   jb/clfft/init.cpp
-jb_libjb_clfft_a_HEADERS = \
+nobase_jb_libjb_clfft_a_HEADERS = \
   jb/clfft/error.hpp \
   jb/clfft/init.hpp \
   jb/clfft/plan.hpp
@@ -837,7 +837,7 @@ jb_clfft_bm_single_fft_LDADD = \
 jb_libjb_tde_a_SOURCES += \
   jb/tde/conjugate_and_multiply_kernel.cpp \
   jb/tde/generic_reduce_program.cpp
-jb_libjb_tde_a_HEADERS += \
+nobase_jb_libjb_tde_a_HEADERS += \
   jb/tde/conjugate_and_multiply_kernel.hpp \
   jb/tde/generic_reduce_program.hpp
 

--- a/jb/itch5/bm_order_book_generate.sh
+++ b/jb/itch5/bm_order_book_generate.sh
@@ -9,7 +9,17 @@ if [ $# -ge 1 ]; then
 fi
 
 bindir=`dirname $0`
-. ${bindir?}/../../tools/benchmark_common.sh
+for path in ${bindir?}/../../tools ${bindir?}; do
+    if [ -r ${path?}/benchmark_common.sh ]; then
+	. ${path?}/benchmark_common.sh
+	benchmark_common_loaded=yes
+	break
+    fi
+done
+if [ "x${benchmark_common_loaded}" = "x" ]; then
+    echo "Cannot load benchmark_common.sh"
+    exit 1
+fi
 
 # ... configure the system to run a benchmark and select where to send
 # output ...


### PR DESCRIPTION
This improves the generated Makefile so something like:

```
make install
```

installs both the benchmarks and their driver scripts.
