### PR TITLE
Simplify docker scripts, eliminate some configs.

### DIFF
--- a/docker/dev/buildall.sh
+++ b/docker/dev/buildall.sh
@@ -2,7 +2,7 @@
 
 tag=$(date +%Y%m%d%H%M)
 bindir=$(dirname $0)
-for target in fedora{23,24,25} ubuntu{14.04,16.04,16.10}; do
+for target in fedora{24,25} ubuntu{14.04,16.04}; do
     echo ================================================================
     echo
     echo Building ${target?} $(date)

--- a/docker/dev/pushall.sh
+++ b/docker/dev/pushall.sh
@@ -10,7 +10,7 @@ if [ "x${tag}" = "x" ]; then
 fi
 
 bindir=$(dirname $0)
-for target in fedora{23,24,25} ubuntu{14.04,16.04,16.10}; do
+for target in fedora{24,25} ubuntu{14.04,16.04}; do
     echo ================================================================
     echo
     echo Pushing ${target?} $(date)

--- a/docker/runtime/buildall.sh
+++ b/docker/runtime/buildall.sh
@@ -2,7 +2,7 @@
 
 tag=$(date +%Y%m%d%H%M)
 bindir=$(dirname $0)
-for target in fedora{23,24,25} ubuntu{14.04,16.04,16.10}; do
+for target in fedora{24,25} ubuntu{14.04,16.04}; do
     echo ================================================================
     echo
     echo Building ${target?} $(date)


### PR DESCRIPTION
Since I no longer use Fedora 23 or Ubuntu 16.10 in the
builds, I can simplify the tools used to create the
docker images.