### PR TITLE
Automatically create docker images in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - uname -a
   - REPO=`git config remote.origin.url`
   - REPO_REF=${REPO/https:\/\/}
-  - docker build --help
+  - docker --version
   - docker pull ${IMAGE?}
   - /usr/bin/env ${COMPILER?} --version
   - docker run --rm -it --env CXX=${COMPILER?} --env CXXFLAGS="${CXXFLAGS}" -v $PWD:$PWD ${IMAGE?} /bin/sh -c "cd $PWD && ./bootstrap && ./configure ${CONFIGUREFLAGS} && make -j 2 check"
@@ -40,6 +40,10 @@ script:
   - if [ "x${CHECK_STYLE}" = "xyes" ]; then
     docker run --rm -it --env CXX=${COMPILER?} --env CXXFLAGS="${CXXFLAGS}" -v $PWD:$PWD ${IMAGE?} /bin/sh -c "cd $PWD && make check-style" ;
     fi
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install docker-engine
 
 install:
   - if [ "x${COVERAGE}" = "xyes" ]; then gem install coveralls-lcov ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ after_success:
     (cd doc/html ; git push https://${GH_TOKEN?}@${REPO_REF?} gh-pages) ;
     fi
   # Create the build image, the script detects if the conditions are not suitable ...
-  - docker login -u ${DOCKER_USER?} -p ${DOCKER_PASSWD?}
+  - docker login -u ${DOCKER_USER?} -p ${DOCKER_PASSWORD?}
   - ci/create-build-image.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,6 @@ after_success:
     (cd doc/html ; git push https://${GH_TOKEN?}@${REPO_REF?} gh-pages) ;
     fi
   # Create the build image, the script detects if the conditions are not suitable ...
-  - docker login -u ${DOCKER_USER?} -p ${DOCKER_PASSWORD?}
   - ci/create-build-image.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ after_success:
     (cd doc/html ; git push https://${GH_TOKEN?}@${REPO_REF?} gh-pages) ;
     fi
   # Create the build image, the script detects if the conditions are not suitable ...
+  - docker login -u ${DOCKER_USER?} -p ${DOCKER_PASSWD?}
   - ci/create-build-image.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,8 @@ after_success:
     docker run --rm -it --env GIT_NAME="${GIT_NAME?}" --env GIT_EMAIL=${GIT_EMAIL?} -v $PWD:/home/${USER?}/jaybeams ${IMAGE?} /bin/sh -c "cd /home/${USER?}/jaybeams && ci/gendocs.sh" ;
     (cd doc/html ; git push https://${GH_TOKEN?}@${REPO_REF?} gh-pages) ;
     fi
-  - if [ "x${TRAVIS_PULL_REQUEST}" = "xfalse" -a "x${TRAVIS_BRANCH}" = "xcreate-docker-on-travis" -a "$IMAGE" = "coryan/jaybeamsdev-fedora25" ]; then
-    docker build -t ${IMAGE}:tip docker/dev/fedora25 ;
-    fi
+  # Create the build image, the script detects if the conditions are not suitable ...
+  - ci/create-build-image.sh
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,9 @@ after_success:
     docker run --rm -it --env GIT_NAME="${GIT_NAME?}" --env GIT_EMAIL=${GIT_EMAIL?} -v $PWD:/home/${USER?}/jaybeams ${IMAGE?} /bin/sh -c "cd /home/${USER?}/jaybeams && ci/gendocs.sh" ;
     (cd doc/html ; git push https://${GH_TOKEN?}@${REPO_REF?} gh-pages) ;
     fi
+  - if [ "x${TRAVIS_PULL_REQUEST}" = "xfalse" -a "x${TRAVIS_BRANCH}" = "xcreate-docker-on-travis" -a "$IMAGE" = "coryan/jaybeamsdev-fedora25" ]; then
+    docker build -t ${IMAGE}:tip docker/dev/fedora25 ;
+    fi
 
 notifications:
   email: false

--- a/ci/create-build-image.sh
+++ b/ci/create-build-image.sh
@@ -1,23 +1,41 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
+env
+
+# Extract the variant from the IMAGE environment variable (it is set in .travis.yml)
+variant=$(echo ${IMAGE?} | sed -e 's;coryan/jaybeamsdev-;;' -e 's/:.*//')
+echo "VARIANT=" ${variant?}
+
 # TODO() add -a "x${TRAVIS_BRANCH}" = "xmaster"
-if [ "x${TRAVIS_PULL_REQUEST}" = "xfalse" ]; then
+if [ "x${TRAVIS_PULL_REQUEST}" != "xfalse" ]; then
+    echo "Testing PR, image creation disabled."
     exit 0
 fi
 
 # TODO() this is just to run less builds during debugging ...
 if [ "x${TRAVIS_BRANCH}" != "xcreate-docker-on-travis" -o \
 			 "$IMAGE" != "coryan/jaybeamsdev-fedora25" ]; then
+    echo "DEBUG: only branch create-docker-on-travis create images"
     exit 0
 fi
 
-# Extract the variant from the IMAGE environment variable (it is set in .travis.yml)
-variant=$(echo ${IMAGE?} | sed -e 's;coryan/jaybeamsdev-;;' -e 's/:.*//')
+# Determine now old is the image, if it is old enough, we re-create
+# from scratch every time ...
+now=$(date +%s)
+image_creation=$(date --date=$(docker inspect -f '{{ .Created }}' ${IMAGE}:latest +%s))
+age_days=$(( (now - image_creation) / 86400 ))
 
-# Build a new docker image, reusing the source image as a cache.  This
-# is why we do not use --squash btw, it would remove the opportunity
-# for caching ...
-docker image build --cache-from=${IMAGE?} -t coryan/jaybeamsdev-${variant?}:tip \
-       -f ${variant?}/Dockerfile  docker/dev
+# By default we reuse the source image as a cache.  This is why we do
+# not use --squash btw, it would remove the opportunity for caching ...
+caching="--cache-from=${IMAGE?}:latest"
+if [ $age_days -ge 30 ]; then
+    caching="--no-cache"
+fi
+
+# Build a new docker image
+docker image build ${caching?} -t coryan/jaybeamsdev-${variant?}:tip \
+       -f ${variant?}/Dockerfile docker/dev
+
+exit 0

--- a/ci/create-build-image.sh
+++ b/ci/create-build-image.sh
@@ -9,8 +9,8 @@ if [ "x${TRAVIS_PULL_REQUEST}" != "xfalse" ]; then
 fi
 
 # TODO() this is just to run less builds during debugging ...
-if [ "x${TRAVIS_BRANCH}" != "xcreate-docker-on-travis" ]; then
-    echo "DEBUG: only branch create-docker-on-travis create images"
+if [ "x${TRAVIS_BRANCH}" != "xmaster" ]; then
+    echo "DEBUG: only create images on master branch."
     exit 0
 fi
 

--- a/ci/create-build-image.sh
+++ b/ci/create-build-image.sh
@@ -28,7 +28,7 @@ variant=$(echo ${IMAGE?} | sed -e 's;coryan/jaybeamsdev-;;')
 # Determine now old is the image, if it is old enough, we re-create
 # from scratch every time ...
 now=$(date +%s)
-image_creation=$(date --date=$(docker inspect -f '{{ .Created }}' ${IMAGE}:latest) +%s)
+image_creation=$(date --date=$(docker inspect -f '{{ .Created }}' ${IMAGE?}:latest) +%s)
 age_days=$(( (now - image_creation) / 86400 ))
 
 # By default we reuse the source image as a cache.  This is why we do
@@ -50,7 +50,7 @@ if [ ${id_tip?} != ${id_latest?} ]; then
     # label so we can keep a history of used images in the registry
     tag=$(date +%Y%m%d%H%M)
     echo "${IMAGE?} has changed, pushing to registry."
-    echo "tip = ${id_tip?}"
+    echo "tip    = ${id_tip?}"
     echo "latest = ${id_latest?}"
     # ... label the image with the new tag ...
     docker image tag ${IMAGE?}:tip ${IMAGE?}:${tag?}

--- a/ci/create-build-image.sh
+++ b/ci/create-build-image.sh
@@ -4,10 +4,6 @@ set -e
 
 env
 
-# Extract the variant from the IMAGE environment variable (it is set in .travis.yml)
-variant=$(echo ${IMAGE?} | sed -e 's;coryan/jaybeamsdev-;;' -e 's/:.*//')
-echo "VARIANT=" ${variant?}
-
 # TODO() add -a "x${TRAVIS_BRANCH}" = "xmaster"
 if [ "x${TRAVIS_PULL_REQUEST}" != "xfalse" ]; then
     echo "Testing PR, image creation disabled."
@@ -21,21 +17,46 @@ if [ "x${TRAVIS_BRANCH}" != "xcreate-docker-on-travis" -o \
     exit 0
 fi
 
+# Extract the variant from the IMAGE environment variable (it is set in .travis.yml)
+IMAGE=$(echo ${IMAGE?} | sed  -e 's/:.*//')
+variant=$(echo ${IMAGE?} | sed -e 's;coryan/jaybeamsdev-;;')
+
 # Determine now old is the image, if it is old enough, we re-create
 # from scratch every time ...
 now=$(date +%s)
-image_creation=$(date --date=$(docker inspect -f '{{ .Created }}' ${IMAGE}:latest +%s))
+image_creation=$(date --date=$(docker inspect -f '{{ .Created }}' ${IMAGE}:latest) +%s)
 age_days=$(( (now - image_creation) / 86400 ))
 
 # By default we reuse the source image as a cache.  This is why we do
 # not use --squash btw, it would remove the opportunity for caching ...
 caching="--cache-from=${IMAGE?}:latest"
-if [ $age_days -ge 30 ]; then
+if [ ${age_days?} -ge 30 ]; then
     caching="--no-cache"
 fi
 
 # Build a new docker image
-docker image build ${caching?} -t coryan/jaybeamsdev-${variant?}:tip \
-       -f ${variant?}/Dockerfile docker/dev
+docker image build ${caching?} -t ${IMAGE?}:tip \
+       -f docker/dev/${variant?}/Dockerfile docker/dev
+
+# Compare the ids of the :tip and :latest ...
+id_tip=$(sudo docker inspect -f '{{ .Id }}' ${IMAGE?}:tip)
+id_latest=$(sudo docker inspect -f '{{ .Id }}' ${IMAGE?}:latest)
+if [ ${id_tip?} != ${id_latest?} ]; then
+    # They are different, we need to push them.  Create a permanent
+    # label so we can keep a history of used images in the registry
+    tag=$(date +%Y%m%d%H%M)
+    echo "${IMAGE?} has changed, pushing to registry."
+    # ... label the image with the new tag ...
+    docker image tag ${IMAGE?}:tip ${IMAGE?}:${tag?}
+    # ... upload the image with that tag ...
+    docker image push ${IMAGE?}:${tag?}
+    # ... if that succeeds then rename :latest and push it.  The
+    # second push should take almost no time, as the layers should all
+    # be uploaded already ...
+    docker image tag ${IMAGE?}:${tag?} ${IMAGE?}:latest
+    docker image push ${IMAGE?}:latest
+else
+    echo "No changes in ${IMAGE?}, not pushing to registry."
+fi
 
 exit 0

--- a/ci/create-build-image.sh
+++ b/ci/create-build-image.sh
@@ -14,6 +14,13 @@ if [ "x${TRAVIS_BRANCH}" != "xcreate-docker-on-travis" ]; then
     exit 0
 fi
 
+if [ -z "${DOCKER_USER?}" ]; then
+    echo "DOCKER_USER not set, docker autobuilds disabled."
+    exit 0
+fi
+
+docker login -u "${DOCKER_USER?}" -p "${DOCKER_PASSWORD?}"
+
 # Extract the variant from the IMAGE environment variable (it is set in .travis.yml)
 IMAGE=$(echo ${IMAGE?} | sed  -e 's/:.*//')
 variant=$(echo ${IMAGE?} | sed -e 's;coryan/jaybeamsdev-;;')
@@ -43,15 +50,17 @@ if [ ${id_tip?} != ${id_latest?} ]; then
     # label so we can keep a history of used images in the registry
     tag=$(date +%Y%m%d%H%M)
     echo "${IMAGE?} has changed, pushing to registry."
+    echo "tip = ${id_tip?}"
+    echo "latest = ${id_latest?}"
     # ... label the image with the new tag ...
     docker image tag ${IMAGE?}:tip ${IMAGE?}:${tag?}
     # ... upload the image with that tag ...
-    docker image push ${IMAGE?}:${tag?}
+#    docker image push ${IMAGE?}:${tag?}
     # ... if that succeeds then rename :latest and push it.  The
     # second push should take almost no time, as the layers should all
     # be uploaded already ...
-    docker image tag ${IMAGE?}:${tag?} ${IMAGE?}:latest
-    docker image push ${IMAGE?}:latest
+#    docker image tag ${IMAGE?}:${tag?} ${IMAGE?}:latest
+#    docker image push ${IMAGE?}:latest
 else
     echo "No changes in ${IMAGE?}, not pushing to registry."
 fi

--- a/ci/create-build-image.sh
+++ b/ci/create-build-image.sh
@@ -55,12 +55,12 @@ if [ ${id_tip?} != ${id_latest?} ]; then
     # ... label the image with the new tag ...
     docker image tag ${IMAGE?}:tip ${IMAGE?}:${tag?}
     # ... upload the image with that tag ...
-#    docker image push ${IMAGE?}:${tag?}
+    docker image push ${IMAGE?}:${tag?}
     # ... if that succeeds then rename :latest and push it.  The
     # second push should take almost no time, as the layers should all
     # be uploaded already ...
-#    docker image tag ${IMAGE?}:${tag?} ${IMAGE?}:latest
-#    docker image push ${IMAGE?}:latest
+    docker image tag ${IMAGE?}:${tag?} ${IMAGE?}:latest
+    docker image push ${IMAGE?}:latest
 else
     echo "No changes in ${IMAGE?}, not pushing to registry."
 fi

--- a/ci/create-build-image.sh
+++ b/ci/create-build-image.sh
@@ -9,8 +9,7 @@ if [ "x${TRAVIS_PULL_REQUEST}" != "xfalse" ]; then
 fi
 
 # TODO() this is just to run less builds during debugging ...
-if [ "x${TRAVIS_BRANCH}" != "xcreate-docker-on-travis" -o \
-			 "$IMAGE" != "coryan/jaybeamsdev-fedora25" ]; then
+if [ "x${TRAVIS_BRANCH}" != "xcreate-docker-on-travis" ]; then
     echo "DEBUG: only branch create-docker-on-travis create images"
     exit 0
 fi

--- a/ci/create-build-image.sh
+++ b/ci/create-build-image.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-env
-
 # TODO() add -a "x${TRAVIS_BRANCH}" = "xmaster"
 if [ "x${TRAVIS_PULL_REQUEST}" != "xfalse" ]; then
     echo "Testing PR, image creation disabled."

--- a/docker/dev/fedora24/Dockerfile
+++ b/docker/dev/fedora24/Dockerfile
@@ -63,6 +63,3 @@ WORKDIR /root
 RUN /bin/rm -fr /var/tmp/build-skye /var/tmp/install-autoconf-archive
 RUN /bin/rm -fr /var/tmp/build-clFFT /var/tmp/build-boost-compute /var/tmp/build-pocl
 RUN dnf clean all
-
-COPY test-image.sh /root/test-image.sh
-CMD ["bash", "/root/test-image.sh"]

--- a/docker/dev/fedora25/Dockerfile
+++ b/docker/dev/fedora25/Dockerfile
@@ -63,6 +63,3 @@ WORKDIR /root
 RUN /bin/rm -fr /var/tmp/build-skye /var/tmp/install-autoconf-archive
 RUN /bin/rm -fr /var/tmp/build-clFFT /var/tmp/build-boost-compute /var/tmp/build-pocl
 RUN dnf clean all
-
-COPY test-image.sh /root/test-image.sh
-CMD ["bash", "/root/test-image.sh"]

--- a/docker/dev/ubuntu14.04/Dockerfile
+++ b/docker/dev/ubuntu14.04/Dockerfile
@@ -82,6 +82,3 @@ RUN cp -r staging/usr/local/include/compute/boost/compute/ /usr/include/boost/
 WORKDIR /root
 RUN /bin/rm -fr /var/tmp/build-skye /var/tmp/install-autoconf-archive
 RUN /bin/rm -fr /var/tmp/build-clFFT /var/tmp/build-boost-compute /var/tmp/build-pocl
-
-COPY test-image.sh /root/test-image.sh
-CMD ["bash", "/root/test-image.sh"]

--- a/docker/dev/ubuntu16.04/Dockerfile
+++ b/docker/dev/ubuntu16.04/Dockerfile
@@ -61,6 +61,3 @@ RUN cp -r staging/usr/local/include/compute/boost/compute/ /usr/include/boost/
 WORKDIR /root
 RUN /bin/rm -fr /var/tmp/build-skye /var/tmp/install-autoconf-archive
 RUN /bin/rm -fr /var/tmp/build-boost-compute /var/tmp/build-pocl
-
-COPY test-image.sh /root/test-image.sh
-CMD ["bash", "/root/test-image.sh"]


### PR DESCRIPTION
This fixes #96.  The docker images are automatically created *if* we are building on the master branch, it is not a pull request, the build succeeds.  The docker image is pushed to the docker registry *if* the image is different than 'latest'.
