### PR TITLE
Reduce docker image size

### DIFF
--- a/docker/dev/fedora24/Dockerfile
+++ b/docker/dev/fedora24/Dockerfile
@@ -1,65 +1,65 @@
 FROM fedora:24
 MAINTAINER Carlos O'Ryan <coryan@users.noreply.github.com>
 
-RUN dnf update -y && dnf install -y \
-    autoconf \
-    autoconf-archive \
-    automake \
-    boost \
-    boost-devel \
-    bzip2-devel \
-    clang \
-    clinfo \
-    cmake \
-    compiler-rt \
-    doxygen \
-    fftw-devel \
-    findutils \
-    gcc-c++ \
-    git \
-    lshw \
-    make \
-    ocl-icd-devel \
-    opencl-headers \
-    patch \
-    pocl-devel \
-    sudo \
-    tar \
-    time \
-    wget \
-    yaml-cpp-devel \
-    zlib-devel
+RUN dnf makecache && dnf install -y \
+      autoconf \
+      autoconf-archive \
+      automake \
+      boost \
+      boost-devel \
+      bzip2-devel \
+      clang \
+      clinfo \
+      cmake \
+      compiler-rt \
+      doxygen \
+      fftw-devel \
+      findutils \
+      gcc-c++ \
+      git \
+      lshw \
+      make \
+      ocl-icd-devel \
+      opencl-headers \
+      patch \
+      pocl-devel \
+      sudo \
+      tar \
+      time \
+      wget \
+      yaml-cpp-devel \
+      zlib-devel && \
+    dnf clean all
+
 
 WORKDIR /var/tmp/build-skye
-RUN wget -q https://github.com/coryan/Skye/releases/download/v0.3.2/skye-0.3.2.tar.gz
-RUN tar -xf skye-0.3.2.tar.gz
-RUN cd skye-0.3.2 && \
+RUN wget -q https://github.com/coryan/Skye/releases/download/v0.3.2/skye-0.3.2.tar.gz && \
+    tar -xf skye-0.3.2.tar.gz && \
+    cd skye-0.3.2 && \
     CXX=g++ CC=gcc ./configure && \
     make check && \
-    make install
-
+    make install && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/build-skye
 
 WORKDIR /var/tmp/build-clFFT
-RUN wget -q https://github.com/clMathLibraries/clFFT/archive/v2.12.2.tar.gz
-RUN tar -xf v2.12.2.tar.gz
-RUN cd clFFT-2.12.2/src && \
+RUN wget -q https://github.com/clMathLibraries/clFFT/archive/v2.12.2.tar.gz && \
+    tar -xf v2.12.2.tar.gz && \
+    cd clFFT-2.12.2/src && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local/clFFT-2.12.2 . && \
     make && \
-    make install
+    make install && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/build-clFFT
 
 # ... use this to avoid setting LD_LIBRARY_PATH everywhere ...
-RUN echo /usr/local/clFFT-2.12.2/lib64 | tee /etc/ld.so.conf.d/clfft-2.12.2.conf
-RUN ldconfig
+RUN echo /usr/local/clFFT-2.12.2/lib64 | tee /etc/ld.so.conf.d/clfft-2.12.2.conf && ldconfig
 
 WORKDIR /var/tmp/build-boost-compute
-RUN wget -q https://github.com/boostorg/compute/archive/boost-1.62.0.tar.gz
-RUN tar -xf boost-1.62.0.tar.gz
-WORKDIR /var/tmp/build-boost-compute/compute-boost-1.62.0
-RUN cmake . && make && make DESTDIR=staging install
-RUN cp -r staging/usr/local/include/compute/boost/compute.hpp /usr/include/boost/
-RUN cp -r staging/usr/local/include/compute/boost/compute/ /usr/include/boost/
+RUN wget -q https://github.com/boostorg/compute/archive/boost-1.62.0.tar.gz && \
+    tar -xf boost-1.62.0.tar.gz && \
+    cd /var/tmp/build-boost-compute/compute-boost-1.62.0 && \
+    cmake . && make && make DESTDIR=staging install && \
+    cp -r staging/usr/local/include/compute/boost/compute.hpp /usr/include/boost/ && \
+    cp -r staging/usr/local/include/compute/boost/compute/ /usr/include/boost/ && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/build-boost-compute
 
 WORKDIR /root
-RUN /bin/rm -fr /var/tmp/build-skye /var/tmp/install-autoconf-archive
-RUN /bin/rm -fr /var/tmp/build-clFFT /var/tmp/build-boost-compute /var/tmp/build-pocl
-RUN dnf clean all

--- a/docker/dev/fedora25/Dockerfile
+++ b/docker/dev/fedora25/Dockerfile
@@ -1,65 +1,78 @@
 FROM fedora:25
 MAINTAINER Carlos O'Ryan <coryan@users.noreply.github.com>
 
-RUN dnf update -y && dnf install -y \
-    autoconf \
-    autoconf-archive \
-    automake \
-    boost \
-    boost-devel \
-    bzip2-devel \
-    clang \
-    clinfo \
-    cmake \
-    compiler-rt \
-    doxygen \
-    fftw-devel \
-    findutils \
-    gcc-c++ \
-    git \
-    lshw \
-    make \
-    ocl-icd-devel \
-    opencl-headers \
-    patch \
-    pocl-devel \
-    sudo \
-    tar \
-    time \
-    wget \
-    yaml-cpp-devel \
-    zlib-devel
+RUN dnf makecache && dnf install -y \
+      autoconf \
+      autoconf-archive \
+      automake \
+      boost \
+      boost-devel \
+      bzip2-devel \
+      clang \
+      clinfo \
+      cmake \
+      compiler-rt \
+      doxygen \
+      fftw-devel \
+      findutils \
+      gcc-c++ \
+      git \
+      lshw \
+      make \
+      ocl-icd-devel \
+      opencl-headers \
+      patch \
+      pocl-devel \
+      sudo \
+      tar \
+      time \
+      wget \
+      yaml-cpp-devel \
+      zlib-devel && \
+    dnf clean all
 
 WORKDIR /var/tmp/build-skye
-RUN wget -q https://github.com/coryan/Skye/releases/download/v0.3.2/skye-0.3.2.tar.gz
-RUN tar -xf skye-0.3.2.tar.gz
-RUN cd skye-0.3.2 && \
+RUN wget -q https://github.com/coryan/Skye/releases/download/v0.3.2/skye-0.3.2.tar.gz && \
+    tar -xf skye-0.3.2.tar.gz && \
+    cd skye-0.3.2 && \
     CXX=g++ CC=gcc ./configure && \
     make check && \
-    make install
-
+    make install && \
+    cd .. && /bin/rm -fr /var/tmp/build-skye
 
 WORKDIR /var/tmp/build-clFFT
-RUN wget -q https://github.com/clMathLibraries/clFFT/archive/v2.12.2.tar.gz
-RUN tar -xf v2.12.2.tar.gz
-RUN cd clFFT-2.12.2/src && \
+RUN wget -q https://github.com/clMathLibraries/clFFT/archive/v2.12.2.tar.gz && \
+    tar -xf v2.12.2.tar.gz && \
+    cd clFFT-2.12.2/src && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local/clFFT-2.12.2 . && \
     make && \
-    make install
+    make install && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/build-clFFT
 
 # ... use this to avoid setting LD_LIBRARY_PATH everywhere ...
-RUN echo /usr/local/clFFT-2.12.2/lib64 | tee /etc/ld.so.conf.d/clfft-2.12.2.conf
-RUN ldconfig
+RUN echo /usr/local/clFFT-2.12.2/lib64 | tee /etc/ld.so.conf.d/clfft-2.12.2.conf && \
+    ldconfig
 
 WORKDIR /var/tmp/build-boost-compute
-RUN wget -q https://github.com/boostorg/compute/archive/boost-1.62.0.tar.gz
-RUN tar -xf boost-1.62.0.tar.gz
-WORKDIR /var/tmp/build-boost-compute/compute-boost-1.62.0
-RUN cmake . && make && make DESTDIR=staging install
-RUN cp -r staging/usr/local/include/compute/boost/compute.hpp /usr/include/boost/
-RUN cp -r staging/usr/local/include/compute/boost/compute/ /usr/include/boost/
+RUN wget -q https://github.com/boostorg/compute/archive/boost-1.62.0.tar.gz && \
+    tar -xf boost-1.62.0.tar.gz && \
+    cd compute-boost-1.62.0 && \
+    cmake . && make && make DESTDIR=staging install && \
+    cp -r staging/usr/local/include/compute/boost/compute.hpp /usr/include/boost/ && \
+    cp -r staging/usr/local/include/compute/boost/compute/ /usr/include/boost/ && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/build-boost-compute
 
 WORKDIR /root
-RUN /bin/rm -fr /var/tmp/build-skye /var/tmp/install-autoconf-archive
-RUN /bin/rm -fr /var/tmp/build-clFFT /var/tmp/build-boost-compute /var/tmp/build-pocl
-RUN dnf clean all
+
+# Boost has deprecated a few headers, warns about it, and other parts of Boost still
+# use them:
+#   https://svn.boost.org/trac/boost/ticket/11860
+#   https://github.com/boostorg/iostreams/pull/24
+#
+# Until 1.62.0 or so is released, we simply remove the wawrnings from Boost.
+# I could just remove them all:
+#    RUN find /usr/include/boost/ -type f -exec sed -i '/pragma message.*deprecated/d' {} \;
+# but I have chosen to be more surgical about it:
+RUN sed -i '/pragma message.*deprecated/d' \
+  /usr/include/boost/type_traits/detail/template_arity_spec.hpp \
+  /usr/include/boost/type_traits/detail/bool_trait_def.hpp

--- a/docker/dev/ubuntu14.04/Dockerfile
+++ b/docker/dev/ubuntu14.04/Dockerfile
@@ -1,84 +1,87 @@
 FROM ubuntu:14.04
 MAINTAINER Carlos O'Ryan <coryan@users.noreply.github.com>
 
-RUN apt-get update
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository -y ppa:ubuntu-toolchain-r/test
-RUN apt-get update && apt-get install -y \
-    automake \
-    clang-3.8 \
-    clinfo \
-    cmake \
-    doxygen \
-    g++-5 \
-    gcc-5 \
-    git \
-    lshw \
-    lcov \
-    libboost1.55-all-dev \
-    libbz2-dev \
-    libclang-3.8-dev \
-    libfftw3-dev \
-    libtool \
-    libyaml-cpp-dev \
-    llvm-3.8 \
-    make \
-    pkg-config \
-    ocl-icd-libopencl1 \
-    ocl-icd-opencl-dev \
-    opencl-headers \
-    sudo \
-    tar \
-    time \
-    wget \
-    xz-utils \
-    zlib1g-dev
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    apt-get update && apt-get install -y \
+      automake \
+      clang-3.8 \
+      clinfo \
+      cmake \
+      doxygen \
+      g++-5 \
+      gcc-5 \
+      git \
+      lshw \
+      lcov \
+      libboost1.55-all-dev \
+      libbz2-dev \
+      libclang-3.8-dev \
+      libfftw3-dev \
+      libtool \
+      libyaml-cpp-dev \
+      llvm-3.8 \
+      make \
+      pkg-config \
+      ocl-icd-libopencl1 \
+      ocl-icd-opencl-dev \
+      opencl-headers \
+      sudo \
+      tar \
+      time \
+      wget \
+      xz-utils \
+      zlib1g-dev && \
+    apt-get clean
 
-RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 90
-RUN update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 90
-RUN update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-3.8 90
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 90
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 90
-RUN update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-5 90
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.8 90 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 90 && \
+    update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-3.8 90 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 90 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 90 && \
+    update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-5 90 
 
 WORKDIR /var/tmp/install-autoconf-archive
-RUN wget -q http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2016.03.20.tar.xz		
-RUN tar -xf autoconf-archive-2016.03.20.tar.xz		
-RUN cd autoconf-archive-2016.03.20 && ./configure --prefix=/usr && make && make install
+RUN wget -q http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2016.03.20.tar.xz && \
+    tar -xf autoconf-archive-2016.03.20.tar.xz && \
+    cd autoconf-archive-2016.03.20 && ./configure --prefix=/usr && make && make install && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/install-autoconf-archive
  
 WORKDIR /var/tmp/build-skye
-RUN wget -q https://github.com/coryan/Skye/releases/download/v0.3.2/skye-0.3.2.tar.gz
-RUN tar -xf skye-0.3.2.tar.gz
-RUN cd skye-0.3.2 && \
+RUN wget -q https://github.com/coryan/Skye/releases/download/v0.3.2/skye-0.3.2.tar.gz && \
+    tar -xf skye-0.3.2.tar.gz && \
+    cd skye-0.3.2 && \
     CXX=g++ CC=gcc ./configure && \
     make check && \
-    make install
+    make install && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/build-skye
 
 WORKDIR /var/tmp/build-pocl
-RUN wget -q http://portablecl.org/downloads/pocl-0.13.tar.gz
-RUN tar -zxf pocl-0.13.tar.gz
-RUN cd pocl-0.13 && ./configure && make && make install
+RUN wget -q http://portablecl.org/downloads/pocl-0.13.tar.gz && \
+    tar -zxf pocl-0.13.tar.gz && \
+    cd pocl-0.13 && ./configure && make && make install && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/build-pocl
 
 WORKDIR /var/tmp/build-clFFT
-RUN wget -q https://github.com/clMathLibraries/clFFT/archive/v2.12.2.tar.gz
-RUN tar -xf v2.12.2.tar.gz
-RUN cd clFFT-2.12.2/src && \
+RUN wget -q https://github.com/clMathLibraries/clFFT/archive/v2.12.2.tar.gz && \
+    tar -xf v2.12.2.tar.gz && \
+    cd clFFT-2.12.2/src && \
     cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local . && \
     make && \
-    make install
+    make install && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/build-clFFT
 
 # ... use this to avoid setting LD_LIBRARY_PATH everywhere ...
-RUN echo /usr/local/lib64 | tee /etc/ld.so.conf.d/clfft-2.12.2.conf
-RUN ldconfig
+RUN echo /usr/local/lib64 | tee /etc/ld.so.conf.d/clfft-2.12.2.conf && ldconfig
 
 WORKDIR /var/tmp/build-boost-compute
-RUN wget -q https://github.com/boostorg/compute/archive/boost-1.62.0.tar.gz
-RUN tar -xf boost-1.62.0.tar.gz
-WORKDIR /var/tmp/build-boost-compute/compute-boost-1.62.0
-RUN cmake . && make && make DESTDIR=staging install
-RUN cp -r staging/usr/local/include/compute/boost/compute.hpp /usr/include/boost/
-RUN cp -r staging/usr/local/include/compute/boost/compute/ /usr/include/boost/
+RUN wget -q https://github.com/boostorg/compute/archive/boost-1.62.0.tar.gz && \
+    tar -xf boost-1.62.0.tar.gz && \
+    cd /var/tmp/build-boost-compute/compute-boost-1.62.0 && \
+    cmake . && make && make DESTDIR=staging install && \
+    cp -r staging/usr/local/include/compute/boost/compute.hpp /usr/include/boost/ && \
+    cp -r staging/usr/local/include/compute/boost/compute/ /usr/include/boost/ && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/build-boost-compute
 
 WORKDIR /root
-RUN /bin/rm -fr /var/tmp/build-skye /var/tmp/install-autoconf-archive
-RUN /bin/rm -fr /var/tmp/build-clFFT /var/tmp/build-boost-compute /var/tmp/build-pocl

--- a/docker/dev/ubuntu16.04/Dockerfile
+++ b/docker/dev/ubuntu16.04/Dockerfile
@@ -2,62 +2,65 @@ FROM ubuntu:16.04
 MAINTAINER Carlos O'Ryan <coryan@users.noreply.github.com>
 
 RUN apt-get update && apt-get install -y \
-    automake \
-    clang \
-    clang-format \
-    cmake \
-    doxygen \
-    findutils \
-    g++ \
-    gcc \
-    git \
-    lcov \
-    libboost-all-dev \
-    libbz2-dev \
-    libclang-dev \
-    libclfft-dev \
-    libfftw3-dev \
-    libyaml-cpp-dev \
-    llvm \
-    lshw \
-    make \
-    ocl-icd-libopencl1 \
-    ocl-icd-opencl-dev \
-    opencl-headers \
-    pkg-config \
-    sudo \
-    tar \
-    time \
-    wget \
-    xz-utils \
-    zlib1g-dev
+      automake \
+      clang \
+      clang-format \
+      cmake \
+      doxygen \
+      findutils \
+      g++ \
+      gcc \
+      git \
+      lcov \
+      libboost-all-dev \
+      libbz2-dev \
+      libclang-dev \
+      libclfft-dev \
+      libfftw3-dev \
+      libyaml-cpp-dev \
+      llvm \
+      lshw \
+      make \
+      ocl-icd-libopencl1 \
+      ocl-icd-opencl-dev \
+      opencl-headers \
+      pkg-config \
+      sudo \
+      tar \
+      time \
+      wget \
+      xz-utils \
+      zlib1g-dev && \
+    apt-get clean
 
 WORKDIR /var/tmp/install-autoconf-archive
-RUN wget -q http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2016.09.16.tar.xz
-RUN tar -xf autoconf-archive-2016.09.16.tar.xz
-RUN cd autoconf-archive-2016.09.16 && ./configure --prefix=/usr && make && make install
+RUN wget -q http://ftpmirror.gnu.org/autoconf-archive/autoconf-archive-2016.03.20.tar.xz && \
+    tar -xf autoconf-archive-2016.03.20.tar.xz && \
+    cd autoconf-archive-2016.03.20 && ./configure --prefix=/usr && make && make install && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/install-autoconf-archive
 
 WORKDIR /var/tmp/build-skye
-RUN wget -q https://github.com/coryan/Skye/releases/download/v0.3.2/skye-0.3.2.tar.gz
-RUN tar -xf skye-0.3.2.tar.gz
-RUN cd skye-0.3.2 && \
+RUN wget -q https://github.com/coryan/Skye/releases/download/v0.3.2/skye-0.3.2.tar.gz && \
+    tar -xf skye-0.3.2.tar.gz && \
+    cd skye-0.3.2 && \
     CXX=g++ CC=gcc CPPFLAGS=-D_GLIBCXX_USE_CXX11_ABI=1 ./configure --with-boost-libdir=/usr/lib/x86_64-linux-gnu && \
     make check && \
-    make install
+    make install && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/build-skye
 
 WORKDIR /var/tmp/build-pocl
-RUN wget -q http://portablecl.org/downloads/pocl-0.13.tar.gz
-RUN tar -zxf pocl-0.13.tar.gz
-RUN cd pocl-0.13 && ./configure && make && make install
+RUN wget -q http://portablecl.org/downloads/pocl-0.13.tar.gz && \
+    tar -zxf pocl-0.13.tar.gz && \
+    cd pocl-0.13 && ./configure && make && make install && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/build-pocl
 
 WORKDIR /var/tmp/build-boost-compute
-RUN wget -q https://github.com/boostorg/compute/archive/boost-1.62.0.tar.gz
-RUN tar -xf boost-1.62.0.tar.gz
-WORKDIR /var/tmp/build-boost-compute/compute-boost-1.62.0
-RUN cmake . && make && make DESTDIR=staging install
-RUN cp -r staging/usr/local/include/compute/boost/compute.hpp /usr/include/boost/
-RUN cp -r staging/usr/local/include/compute/boost/compute/ /usr/include/boost/
+RUN wget -q https://github.com/boostorg/compute/archive/boost-1.62.0.tar.gz && \
+    tar -xf boost-1.62.0.tar.gz && \
+    cd /var/tmp/build-boost-compute/compute-boost-1.62.0 && \
+    cmake . && make && make DESTDIR=staging install && \
+    cp -r staging/usr/local/include/compute/boost/compute.hpp /usr/include/boost/ && \
+    cp -r staging/usr/local/include/compute/boost/compute/ /usr/include/boost/ && \
+    cd /var/tmp && /bin/rm -fr /var/tmp/build-boost-compute
 
 WORKDIR /root
-RUN /bin/rm -fr /var/tmp/build-skye /var/tmp/install-autoconf-archive
-RUN /bin/rm -fr /var/tmp/build-boost-compute /var/tmp/build-pocl


### PR DESCRIPTION
This fixes #109.  I think I implemented all the standard practices for smaller images:

* Run the cleanup of each RUN command in the same command (so the temporary files do not take space)
* Reduce the number of layers.
* Avoid a full `apt-get upgrade` or `dnf update`, just refetch the packet lists.
