### PR TITLE
Fix more warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,10 @@ AC_PROG_CXX
 AC_PROG_RANLIB
 
 # ... on Fedora the default ARFLAGS/AR_FLAGS produce warnings ...
-m4_divert_text([DEFAULTS], [: "${ARFLAGS=cr} ${AR_FLAGS=cr}"])
+ARFLAGS=cr
+AR_FLAGS=cr
+AC_SUBST(ARFLAGS)
+AC_SUBST(AR_FLAGS)
 
 # ... check if there is a clang-format installed, allow the user to
 # override the default by setting the CLANG_FORMAT environment

--- a/docker/dev/fedora24/Dockerfile
+++ b/docker/dev/fedora24/Dockerfile
@@ -63,3 +63,16 @@ RUN wget -q https://github.com/boostorg/compute/archive/boost-1.62.0.tar.gz && \
     cd /var/tmp && /bin/rm -fr /var/tmp/build-boost-compute
 
 WORKDIR /root
+
+# Boost has deprecated a few headers, warns about it, and other parts of Boost still
+# use them:
+#   https://svn.boost.org/trac/boost/ticket/11860
+#   https://github.com/boostorg/iostreams/pull/24
+#
+# Until 1.62.0 or so is released, we simply remove the wawrnings from Boost.
+# I could just remove them all:
+#    RUN find /usr/include/boost/ -type f -exec sed -i '/pragma message.*deprecated/d' {} \;
+# but I have chosen to be more surgical about it:
+RUN sed -i '/pragma message.*deprecated/d' \
+  /usr/include/boost/type_traits/detail/template_arity_spec.hpp \
+  /usr/include/boost/type_traits/detail/bool_trait_def.hpp


### PR DESCRIPTION
Fixed warnings for ar(1) on Ubuntu 16.04 and about deprecated files on Fedora 24.
