### PR TITLE
Refactor benchmarks to use jb::testing::microbenchmark_group_main()

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -724,7 +724,10 @@ jb_fftw_bm_time_delay_estimator_many_LDFLAGS = \
 ################################################################
 if HAVE_OPENCL
 
-lib_LIBRARIES += jb/libjb_opencl.a
+lib_LIBRARIES += \
+  jb/libjb_opencl.a \
+  jb/libjb_opencl_testing.a
+
 jb_opencl_unit_tests = \
   jb/opencl/ut_build_simple_kernel \
   jb/opencl/ut_copy_to_host_async \
@@ -773,7 +776,8 @@ jb_ut_tde_ldflags = \
   $(jb_ut_clfft_ldflags)
 
 AM_CXXFLAGS += \
-  $(OPENCL_CPPFLAGS) -D__CL_ENABLE_EXCEPTIONS $(CLFFT_CPPFLAGS) $(BOOST_COMPUTE_CPPFLAGS)
+  $(OPENCL_CPPFLAGS) -D__CL_ENABLE_EXCEPTIONS \
+  $(CLFFT_CPPFLAGS) $(BOOST_COMPUTE_CPPFLAGS)
 
 check_PROGRAMS += \
   $(jb_opencl_unit_tests) \
@@ -811,6 +815,9 @@ jb/opencl/generic_reduce_program.cpp: jb/opencl/generic_reduce_program.cl Makefi
 	cat $< >>$@; \
 	echo ')""";' >> $@
 
+
+# Unit tests for jb/libjb_opencl.a
+
 jb_opencl_ut_build_simple_kernel_SOURCES = jb/opencl/ut_build_simple_kernel.cpp
 jb_opencl_ut_build_simple_kernel_CPPFLAGS = $(UT_CPPFLAGS) -DBOOST_TEST_MODULE=jb_opencl_ut_build_simple_kernel
 jb_opencl_ut_build_simple_kernel_LDFLAGS = $(jb_opencl_ldflags)
@@ -841,15 +848,39 @@ jb_opencl_show_device_LDADD = jb/libjb_opencl.a jb/libjb.a $(OPENCL_LIB)
 
 jb_opencl_bm_copy_buffer_SOURCES = jb/opencl/bm_copy_buffer.cpp
 jb_opencl_bm_copy_buffer_LDFLAGS = $(jb_opencl_ldflags)
-jb_opencl_bm_copy_buffer_LDADD = jb/libjb_testing.a jb/libjb_opencl.a jb/libjb.a $(OPENCL_LIB)
+jb_opencl_bm_copy_buffer_LDADD = \
+  jb/libjb_testing.a \
+  jb/libjb_opencl_testing.a \
+  jb/libjb_opencl.a \
+  jb/libjb.a \
+  $(OPENCL_LIB)
 
 jb_opencl_bm_generic_reduce_SOURCES = jb/opencl/bm_generic_reduce.cpp
 jb_opencl_bm_generic_reduce_LDFLAGS = $(jb_opencl_ldflags)
-jb_opencl_bm_generic_reduce_LDADD = jb/libjb_testing.a jb/libjb_opencl.a jb/libjb.a $(OPENCL_LIB)
+jb_opencl_bm_generic_reduce_LDADD = \
+  jb/libjb_testing.a \
+  jb/libjb_opencl_testing.a \
+  jb/libjb_opencl.a \
+  jb/libjb.a \
+  $(OPENCL_LIB)
 
 jb_opencl_bm_launch_kernel_SOURCES = jb/opencl/bm_launch_kernel.cpp
 jb_opencl_bm_launch_kernel_LDFLAGS =   $(jb_opencl_ldflags)
-jb_opencl_bm_launch_kernel_LDADD = jb/libjb_testing.a jb/libjb_opencl.a jb/libjb.a $(OPENCL_LIB)
+jb_opencl_bm_launch_kernel_LDADD = \
+  jb/libjb_testing.a \
+  jb/libjb_opencl_testing.a \
+  jb/libjb_opencl.a \
+  jb/libjb.a \
+  $(OPENCL_LIB)
+
+#
+# jb/libjb_opencl_testing.a
+#
+jb_libjb_opencl_testing_adir = $(includedir)
+jb_libjb_opencl_testing_a_SOURCES = \
+  jb/opencl/microbenchmark_config.cpp
+nobase_jb_libjb_opencl_testing_a_HEADERS = \
+  jb/opencl/microbenchmark_config.hpp
 
 #
 # jb/libjb_clfft.a
@@ -882,6 +913,7 @@ jb_clfft_bm_single_fft_LDFLAGS = \
 jb_clfft_bm_single_fft_LDADD = \
   jb/libjb_testing.a \
   jb/libjb_clfft.a \
+  jb/libjb_opencl_testing.a \
   jb/libjb_opencl.a \
   jb/libjb.a \
   $(CLFFT_LIB) \
@@ -926,6 +958,7 @@ jb_tde_bm_reduce_argmax_real_LDADD = \
   jb/libjb_testing.a \
   jb/libjb_tde.a \
   jb/libjb_clfft.a \
+  jb/libjb_opencl_testing.a \
   jb/libjb_opencl.a \
   jb/libjb.a \
   $(CLFFT_LIB) \

--- a/jb/bm_clocks.cpp
+++ b/jb/bm_clocks.cpp
@@ -1,4 +1,5 @@
 #include <jb/testing/microbenchmark.hpp>
+#include <jb/testing/microbenchmark_group_main.hpp>
 
 #include <chrono>
 #include <iostream>
@@ -9,56 +10,13 @@
  * Convenience types and functions for benchmarking std::chrono clocks.
  */
 namespace {
-
-/**
- * Base class for the std::chrono clock wrapper.
- */
-class wrapped_clock_base {
-public:
-  virtual ~wrapped_clock_base() {
-  }
-
-  virtual void run() const = 0;
-};
-
-/**
- * The fixture tested by the microbenchmark.
- */
-class fixture {
-public:
-  fixture(std::string const& clock_name);
-  fixture(int size, std::string const& clock_name);
-
-  int run();
-
-private:
-  std::unique_ptr<wrapped_clock_base> wrapped_clock_;
-};
-
-typedef jb::testing::microbenchmark<fixture> benchmark;
-
+using config = jb::testing::microbenchmark_config;
+jb::testing::microbenchmark_group<config> create_testcases();
 } // anonymous namespace
 
-int main(int argc, char* argv[]) try {
-  jb::testing::microbenchmark_config cfg;
-  cfg.test_case("std::chrono::steady_clock").process_cmdline(argc, argv);
-
-  std::cout << "Configuration for test\n" << cfg << std::endl;
-
-  benchmark bm(cfg);
-  auto r = bm.run(cfg.test_case());
-  bm.typical_output(r);
-
-  return 0;
-} catch (jb::usage const& ex) {
-  std::cerr << "usage: " << ex.what() << std::endl;
-  return 1;
-} catch (std::exception const& ex) {
-  std::cerr << "standard exception raised: " << ex.what() << std::endl;
-  return 1;
-} catch (...) {
-  std::cerr << "unknown exception raised" << std::endl;
-  return 1;
+int main(int argc, char* argv[]) {
+  auto testcases = create_testcases();
+  return jb::testing::microbenchmark_group_main(argc, argv, testcases);
 }
 
 namespace {
@@ -77,77 +35,72 @@ int clock_repetitions = JB_DEFAULTS_clock_repetitions;
 } // namespace defaults
 
 /**
- * Wrap a std::chrono class in a polymorphic class.
+ * The fixture tested by the microbenchmark.
+ *
+ * @tparam clock_type the type of clock tested
  */
-template <typename clock>
-class wrapped_clock : public wrapped_clock_base {
+template <typename clock_type>
+class fixture {
 public:
-  wrapped_clock(int calls_per_iteration)
-      : calls_per_iteration_(calls_per_iteration) {
+  fixture()
+      : fixture(defaults::clock_repetitions) {
   }
 
-  virtual void run() const override {
+  fixture(int size)
+      : calls_per_iteration_(size) {
+  }
+
+  int run() {
     for (int i = 0; i != calls_per_iteration_; ++i) {
-      clock::now();
+      (void)clock_type::now();
     }
+    return calls_per_iteration_;
   }
 
 private:
   int calls_per_iteration_;
 };
 
-static std::uint64_t read_rdtscp() {
-  std::uint64_t hi, lo;
-  std::uint32_t aux;
-  __asm__ __volatile__("rdtscp\n" : "=a"(lo), "=d"(hi), "=c"(aux) : :);
-  return (hi << 32) + lo;
-}
-
-class wrapped_rdtscp : public wrapped_clock_base {
-public:
-  wrapped_rdtscp(int calls_per_iteration)
-      : calls_per_iteration_(calls_per_iteration) {
+/// Fake a std::chrono clock using rdtscp
+struct wrapped_rtdscp {
+  static std::uint64_t now() {
+    std::uint64_t hi, lo;
+    std::uint32_t aux;
+    __asm__ __volatile__("rdtscp\n" : "=a"(lo), "=d"(hi), "=c"(aux) : :);
+    return (hi << 32) + lo;
   }
-
-  virtual void run() const override {
-    for (int i = 0; i != calls_per_iteration_; ++i) {
-      (void)read_rdtscp();
-    }
-  }
-
-private:
-  int calls_per_iteration_;
 };
 
-fixture::fixture(std::string const& clock_name)
-    : fixture(defaults::clock_repetitions, clock_name) {
+/// Fake a std::chrono clock using rdtsc
+struct wrapped_rtdsc {
+  static std::uint64_t now() {
+    std::uint64_t hi, lo;
+    std::uint32_t aux;
+    __asm__ __volatile__("rdtsc\n" : "=a"(lo), "=d"(hi), "=c"(aux) : :);
+    return (hi << 32) + lo;
+  }
+};
+
+template <typename clock_type>
+std::function<void(config const&)> test_case() {
+  return [](config const& cfg) {
+    using benchmark = jb::testing::microbenchmark<fixture<clock_type>>;
+    benchmark bm(cfg);
+    auto r = bm.run();
+    bm.typical_output(r);
+  };
 }
 
-fixture::fixture(int size, std::string const& clock_name) {
+jb::testing::microbenchmark_group<config> create_testcases() {
   using namespace std::chrono;
-  if (clock_name == "std::chrono::steady_clock") {
-    wrapped_clock_.reset(new wrapped_clock<steady_clock>(size));
-  } else if (clock_name == "std::chrono::high_resolution_clock") {
-    wrapped_clock_.reset(new wrapped_clock<high_resolution_clock>(size));
-  } else if (clock_name == "std::chrono::system_clock") {
-    wrapped_clock_.reset(new wrapped_clock<system_clock>(size));
-  } else if (clock_name == "rdtscp") {
-    wrapped_clock_.reset(new wrapped_rdtscp(size));
-  } else {
-    std::ostringstream os;
-    os << "unknown value for --clock-name (" << clock_name << ")\n";
-    os << "value must be one of"
-       << ": std::chrono::steady_clock"
-       << ", std::chrono::high_resolution_clock"
-       << ", std::chrono::system_clock"
-       << ", rdtscp";
-    throw jb::usage(os.str(), 1);
-  }
-}
-
-int fixture::run() {
-  wrapped_clock_->run();
-  return 0;
+  return jb::testing::microbenchmark_group<config>{
+      {"std::chrono::steady_clock", test_case<steady_clock>()},
+      {"std::chrono::high_resolution_clock",
+       test_case<high_resolution_clock>()},
+      {"std::chrono::system_clock_clock", test_case<system_clock>()},
+      {"rdtscp", test_case<wrapped_rtdscp>()},
+      {"rdtsc", test_case<wrapped_rtdsc>()},
+  };
 }
 
 } // anonymous namespace

--- a/jb/clfft/bm_single_fft.cpp
+++ b/jb/clfft/bm_single_fft.cpp
@@ -1,7 +1,7 @@
 #include <jb/clfft/plan.hpp>
-#include <jb/opencl/config.hpp>
 #include <jb/opencl/copy_to_host_async.hpp>
 #include <jb/opencl/device_selector.hpp>
+#include <jb/opencl/microbenchmark_config.hpp>
 #include <jb/testing/microbenchmark.hpp>
 
 #include <boost/compute/command_queue.hpp>
@@ -11,17 +11,7 @@
 #include <string>
 
 namespace {
-
-class config : public jb::config_object {
-public:
-  config()
-      : benchmark(desc("benchmark"), this)
-      , opencl(desc("opencl"), this) {
-  }
-
-  jb::config_attribute<config, jb::testing::microbenchmark_config> benchmark;
-  jb::config_attribute<config, jb::opencl::config> opencl;
-};
+using config = jb::opencl::microbenchmark_config;
 
 int nsamples = 2048;
 
@@ -79,7 +69,7 @@ void benchmark_test_case(config const& cfg) {
   boost::compute::context context(device);
   boost::compute::command_queue queue(context, device);
   typedef jb::testing::microbenchmark<fixture<pipelined>> benchmark;
-  benchmark bm(cfg.benchmark());
+  benchmark bm(cfg.microbenchmark());
 
   auto r = bm.run(context, queue);
   bm.typical_output(r);
@@ -89,13 +79,13 @@ void benchmark_test_case(config const& cfg) {
 
 int main(int argc, char* argv[]) try {
   config cfg;
-  cfg.benchmark(
+  cfg.microbenchmark(
          jb::testing::microbenchmark_config().test_case("complex:float:async"))
       .process_cmdline(argc, argv);
 
   std::cout << "Configuration for test\n" << cfg << std::endl;
 
-  auto test_case = cfg.benchmark().test_case();
+  auto test_case = cfg.microbenchmark().test_case();
   if (test_case == "complex:float:async") {
     benchmark_test_case<true>(cfg);
   } else if (test_case == "complex:float:sync") {

--- a/jb/opencl/bm_copy_buffer.cpp
+++ b/jb/opencl/bm_copy_buffer.cpp
@@ -1,4 +1,4 @@
-#include <jb/opencl/config.hpp>
+#include <jb/opencl/microbenchmark_config.hpp>
 #include <jb/opencl/copy_to_host_async.hpp>
 #include <jb/opencl/device_selector.hpp>
 #include <jb/testing/microbenchmark.hpp>
@@ -14,21 +14,7 @@
 #include <unistd.h>
 
 namespace {
-class config : public jb::config_object {
-public:
-  config()
-      : microbenchmark(
-            desc("microbenchmark"), this,
-            jb::testing::microbenchmark_config().test_case("upload:aligned"))
-      , log(desc("log", "log"), this)
-      , opencl(desc("opencl"), this) {
-  }
-
-  jb::config_attribute<config, jb::testing::microbenchmark_config>
-      microbenchmark;
-  jb::config_attribute<config, jb::log::config> log;
-  jb::config_attribute<config, jb::opencl::config> opencl;
-};
+using config = jb::opencl::microbenchmark_config;
 
 /// Create all the testcases
 jb::testing::microbenchmark_group<config> create_test_cases();

--- a/jb/opencl/bm_copy_buffer.cpp
+++ b/jb/opencl/bm_copy_buffer.cpp
@@ -2,6 +2,7 @@
 #include <jb/opencl/copy_to_host_async.hpp>
 #include <jb/opencl/device_selector.hpp>
 #include <jb/testing/microbenchmark.hpp>
+#include <jb/testing/microbenchmark_group_main.hpp>
 
 #include <boost/compute/algorithm/copy.hpp>
 #include <boost/compute/command_queue.hpp>
@@ -13,18 +14,35 @@
 #include <unistd.h>
 
 namespace {
-
 class config : public jb::config_object {
 public:
   config()
-      : benchmark(desc("benchmark"), this)
+      : microbenchmark(
+            desc("microbenchmark"), this,
+            jb::testing::microbenchmark_config().test_case("upload:aligned"))
+      , log(desc("log", "log"), this)
       , opencl(desc("opencl"), this) {
   }
 
-  jb::config_attribute<config, jb::testing::microbenchmark_config> benchmark;
+  jb::config_attribute<config, jb::testing::microbenchmark_config>
+      microbenchmark;
+  jb::config_attribute<config, jb::log::config> log;
   jb::config_attribute<config, jb::opencl::config> opencl;
 };
 
+/// Create all the testcases
+jb::testing::microbenchmark_group<config> create_test_cases();
+
+} // anonymous namespace
+
+int main(int argc, char* argv[]) {
+  // Simply call the generic microbenchmark for a group of testcases
+  // ...
+  auto testcases = create_test_cases();
+  return jb::testing::microbenchmark_group_main<config>(argc, argv, testcases);
+}
+
+namespace {
 // By default use a single page, at least a typical page size
 int get_page_size() {
   return static_cast<int>(sysconf(_SC_PAGESIZE));
@@ -93,54 +111,29 @@ int fixture<false>::run() {
 
 template <bool upload>
 void benchmark_test_case(config const& cfg, bool aligned) {
-  boost::compute::device device = jb::opencl::device_selector(cfg.opencl());
-  boost::compute::context context(device);
-  boost::compute::command_queue queue(context, device);
-  typedef jb::testing::microbenchmark<fixture<upload>> benchmark;
-  benchmark bm(cfg.benchmark());
+}
 
-  auto r = bm.run(context, queue, aligned);
-  bm.typical_output(r);
+template <bool upload, bool aligned>
+std::function<void(config const&)> test_case() {
+  return [](config const& cfg) {
+    boost::compute::device device = jb::opencl::device_selector(cfg.opencl());
+    boost::compute::context context(device);
+    boost::compute::command_queue queue(context, device);
+    typedef jb::testing::microbenchmark<fixture<upload>> benchmark;
+    benchmark bm(cfg.microbenchmark());
+
+    auto r = bm.run(context, queue, aligned);
+    bm.typical_output(r);
+  };
+}
+
+jb::testing::microbenchmark_group<config> create_test_cases() {
+  return jb::testing::microbenchmark_group<config>{
+      {"upload:aligned", test_case<true, true>()},
+      {"upload:misaligned", test_case<true, false>()},
+      {"download:aligned", test_case<false, true>()},
+      {"download:misaligned", test_case<false, false>()},
+  };
 }
 
 } // anonymous namespace
-
-int main(int argc, char* argv[]) try {
-  config cfg;
-  cfg.benchmark(
-         jb::testing::microbenchmark_config().test_case("upload:aligned"))
-      .process_cmdline(argc, argv);
-
-  std::cerr << "Configuration for test\n" << cfg << std::endl;
-
-  auto test_case = cfg.benchmark().test_case();
-  if (test_case == "upload:aligned") {
-    benchmark_test_case<true>(cfg, true);
-  } else if (test_case == "upload:misaligned") {
-    benchmark_test_case<true>(cfg, false);
-  } else if (test_case == "download:aligned") {
-    benchmark_test_case<false>(cfg, true);
-  } else if (test_case == "download:misaligned") {
-    benchmark_test_case<false>(cfg, false);
-  } else {
-    std::ostringstream os;
-    os << "Unknown test case (" << test_case << ")" << std::endl;
-    os << " --test-case must be one of"
-       << ": upload:aligned"
-       << ", upload:misaligned"
-       << ", download:saligned"
-       << ", download:misaligned" << std::endl;
-    throw jb::usage(os.str(), 1);
-  }
-
-  return 0;
-} catch (jb::usage const& ex) {
-  std::cerr << "usage: " << ex.what() << std::endl;
-  return ex.exit_status();
-} catch (std::exception const& ex) {
-  std::cerr << "standard exception raised: " << ex.what() << std::endl;
-  return 1;
-} catch (...) {
-  std::cerr << "unknown exception raised" << std::endl;
-  return 1;
-}

--- a/jb/opencl/bm_copy_buffer.cpp
+++ b/jb/opencl/bm_copy_buffer.cpp
@@ -1,6 +1,6 @@
-#include <jb/opencl/microbenchmark_config.hpp>
 #include <jb/opencl/copy_to_host_async.hpp>
 #include <jb/opencl/device_selector.hpp>
+#include <jb/opencl/microbenchmark_config.hpp>
 #include <jb/testing/microbenchmark.hpp>
 #include <jb/testing/microbenchmark_group_main.hpp>
 

--- a/jb/opencl/bm_generic_reduce.cpp
+++ b/jb/opencl/bm_generic_reduce.cpp
@@ -1,4 +1,4 @@
-#include <jb/opencl/config.hpp>
+#include <jb/opencl/microbenchmark_config.hpp>
 #include <jb/opencl/device_selector.hpp>
 #include <jb/opencl/generic_reduce.hpp>
 #include <jb/testing/initialize_mersenne_twister.hpp>
@@ -21,15 +21,11 @@ namespace {
 /**
  * The configuration class for this benchmark.
  */
-class config : public jb::config_object {
+class config : public jb::opencl::microbenchmark_config {
 public:
   config();
   config_object_constructors(config);
 
-  jb::config_attribute<config, jb::testing::microbenchmark_config>
-      microbenchmark;
-  jb::config_attribute<config, jb::log::config> log;
-  jb::config_attribute<config, jb::opencl::config> opencl;
   jb::config_attribute<config, bool> randomize_size;
   jb::config_attribute<config, bool> copy_data;
 };
@@ -56,11 +52,7 @@ std::string randomize_size_help() {
 }
 
 config::config()
-    : microbenchmark(
-          desc("microbenchmark", "microbenchmark"), this,
-          jb::testing::microbenchmark_config().test_case("float:boost"))
-    , log(desc("log", "log"), this)
-    , opencl(desc("opencl"), this)
+    : microbenchmark_config()
     , randomize_size(
           desc("randomize-size").help(randomize_size_help()), this, true)
     , copy_data(

--- a/jb/opencl/bm_generic_reduce.cpp
+++ b/jb/opencl/bm_generic_reduce.cpp
@@ -1,6 +1,6 @@
-#include <jb/opencl/microbenchmark_config.hpp>
 #include <jb/opencl/device_selector.hpp>
 #include <jb/opencl/generic_reduce.hpp>
+#include <jb/opencl/microbenchmark_config.hpp>
 #include <jb/testing/initialize_mersenne_twister.hpp>
 #include <jb/testing/microbenchmark.hpp>
 #include <jb/testing/microbenchmark_group_main.hpp>

--- a/jb/opencl/bm_launch_kernel.cpp
+++ b/jb/opencl/bm_launch_kernel.cpp
@@ -58,8 +58,13 @@ private:
   boost::compute::kernel kernel;
   boost::compute::command_queue queue;
 };
+} // anonymous namespace
 
-void benchmark_test_case(config const& cfg) {
+int main(int argc, char* argv[]) try {
+  config cfg;
+  cfg.process_cmdline(argc, argv);
+  std::cerr << "Configuration for test\n" << cfg << std::endl;
+
   boost::compute::device device = jb::opencl::device_selector(cfg.opencl());
   boost::compute::context context(device);
   boost::compute::command_queue queue(context, device);
@@ -68,16 +73,6 @@ void benchmark_test_case(config const& cfg) {
 
   auto r = bm.run(context, queue);
   bm.typical_output(r);
-}
-
-} // anonymous namespace
-
-int main(int argc, char* argv[]) try {
-  config cfg;
-  cfg.process_cmdline(argc, argv);
-  std::cerr << "Configuration for test\n" << cfg << std::endl;
-
-  benchmark_test_case(cfg);
 
   return 0;
 } catch (jb::usage const& ex) {

--- a/jb/opencl/bm_launch_kernel.cpp
+++ b/jb/opencl/bm_launch_kernel.cpp
@@ -1,6 +1,6 @@
 #include <jb/opencl/build_simple_kernel.hpp>
-#include <jb/opencl/microbenchmark_config.hpp>
 #include <jb/opencl/device_selector.hpp>
+#include <jb/opencl/microbenchmark_config.hpp>
 #include <jb/testing/microbenchmark.hpp>
 
 #include <boost/compute/algorithm/copy.hpp>

--- a/jb/opencl/bm_launch_kernel.cpp
+++ b/jb/opencl/bm_launch_kernel.cpp
@@ -1,5 +1,5 @@
 #include <jb/opencl/build_simple_kernel.hpp>
-#include <jb/opencl/config.hpp>
+#include <jb/opencl/microbenchmark_config.hpp>
 #include <jb/opencl/device_selector.hpp>
 #include <jb/testing/microbenchmark.hpp>
 
@@ -11,17 +11,7 @@
 #include <string>
 
 namespace {
-
-class config : public jb::config_object {
-public:
-  config()
-      : benchmark(desc("benchmark"), this)
-      , opencl(desc("opencl"), this) {
-  }
-
-  jb::config_attribute<config, jb::testing::microbenchmark_config> benchmark;
-  jb::config_attribute<config, jb::opencl::config> opencl;
-};
+using config = jb::opencl::microbenchmark_config;
 
 char const source[] = R"""(
 __kernel void empty() {
@@ -69,7 +59,7 @@ int main(int argc, char* argv[]) try {
   boost::compute::context context(device);
   boost::compute::command_queue queue(context, device);
   typedef jb::testing::microbenchmark<fixture> benchmark;
-  benchmark bm(cfg.benchmark());
+  benchmark bm(cfg.microbenchmark());
 
   auto r = bm.run(context, queue);
   bm.typical_output(r);

--- a/jb/opencl/microbenchmark_config.cpp
+++ b/jb/opencl/microbenchmark_config.cpp
@@ -1,0 +1,7 @@
+#include "jb/opencl/microbenchmark_config.hpp"
+
+jb::opencl::microbenchmark_config::microbenchmark_config()
+    : microbenchmark(desc("microbenchmark", "microbenchmark"), this)
+    , log(desc("log", "log"), this)
+    , opencl(desc("opencl"), this) {
+}

--- a/jb/opencl/microbenchmark_config.hpp
+++ b/jb/opencl/microbenchmark_config.hpp
@@ -1,0 +1,29 @@
+#ifndef jb_opencl_microbenchmark_config_hpp
+#define jb_opencl_microbenchmark_config_hpp
+
+#include <jb/opencl/config.hpp>
+#include <jb/testing/microbenchmark_config.hpp>
+#include <jb/log.hpp>
+
+namespace jb {
+namespace opencl {
+/**
+ * The configuration shared by all OpenCL microbenchmarks.
+ */
+class microbenchmark_config : public jb::config_object {
+public:
+  microbenchmark_config();
+  config_object_constructors(microbenchmark_config);
+
+  jb::config_attribute<microbenchmark_config,
+                       jb::testing::microbenchmark_config>
+      microbenchmark;
+  jb::config_attribute<microbenchmark_config, jb::log::config> log;
+  jb::config_attribute<microbenchmark_config, jb::opencl::config> opencl;
+};
+
+
+} // namespace opencl
+} // namespace jb
+
+#endif // jb_opencl_microbenchmark_config_hpp

--- a/jb/opencl/microbenchmark_config.hpp
+++ b/jb/opencl/microbenchmark_config.hpp
@@ -22,7 +22,6 @@ public:
   jb::config_attribute<microbenchmark_config, jb::opencl::config> opencl;
 };
 
-
 } // namespace opencl
 } // namespace jb
 

--- a/jb/tde/bm_reduce_argmax_real.cpp
+++ b/jb/tde/bm_reduce_argmax_real.cpp
@@ -1,30 +1,49 @@
 #include <jb/opencl/config.hpp>
 #include <jb/opencl/device_selector.hpp>
-#include <jb/testing/create_random_timeseries.hpp>
 #include <jb/testing/microbenchmark.hpp>
+#include <jb/testing/microbenchmark_group_main.hpp>
 #include <jb/complex_traits.hpp>
+#include <jb/log.hpp>
 
 #include <boost/compute/algorithm/max_element.hpp>
 #include <boost/compute/container/vector.hpp>
 #include <boost/compute/context.hpp>
 #include <boost/compute/types/complex.hpp>
 #include <iostream>
-#include <random>
 #include <stdexcept>
 #include <string>
 
+/// Functions and types to benchmark the argmax reduction based on
+/// Boost.Compute
 namespace {
-
 class config : public jb::config_object {
 public:
-  config()
-      : benchmark(desc("benchmark"), this)
-      , opencl(desc("opencl"), this) {
-  }
+  config();
+  config_object_constructors(config);
 
-  jb::config_attribute<config, jb::testing::microbenchmark_config> benchmark;
+  jb::config_attribute<config, jb::testing::microbenchmark_config>
+      microbenchmark;
+  jb::config_attribute<config, jb::log::config> log;
   jb::config_attribute<config, jb::opencl::config> opencl;
 };
+
+/// Return a table with all the testcases ..
+jb::testing::microbenchmark_group<config> create_testcases();
+} // anonymous namespace
+
+int main(int argc, char* argv[]) {
+  auto testcases = create_testcases();
+  return jb::testing::microbenchmark_group_main<config>(argc, argv, testcases);
+}
+
+namespace {
+config::config()
+    : microbenchmark(
+          desc("microbenchmark", "microbenchmark"), this,
+          jb::testing::microbenchmark_config().test_case("gpu:float"))
+    , log(desc("log", "log"), this)
+    , opencl(desc("opencl", "opencl"), this) {
+}
 
 constexpr int default_size() {
   return 32768;
@@ -69,12 +88,22 @@ std::size_t cpu_argmax(std::vector<T> const& host) {
       host.begin(), std::max_element(host.begin(), host.end(), less_real));
 }
 
-template <typename value_type, bool use_gpu = false>
+/**
+ * The benchmark fixture.
+ *
+ * @tparam value_type the values stored in the vector.
+ * @tparam use_gpu if true, the computation is executed using
+ * Boost.Compute, and presumably OpenCL in the GPU.
+ */
+template <typename value_type, bool use_gpu>
 class fixture {
 public:
+  /// Constructor
   fixture(boost::compute::context& context, boost::compute::command_queue& q)
       : fixture(default_size(), context, q) {
   }
+
+  /// Constructor with a size
   fixture(
       int size, boost::compute::context& context,
       boost::compute::command_queue& q)
@@ -82,14 +111,12 @@ public:
       , host(size)
       , queue(q)
       , unused(0) {
-    typedef typename jb::extract_value_type<value_type>::precision precision_t;
-    unsigned int seed = std::random_device()();
-    std::mt19937 gen(seed);
-    std::uniform_real_distribution<precision_t> dis(-1000, 1000);
-    auto generator = [&gen, &dis]() { return dis(gen); };
-    std::cerr << "SEED = " << seed << std::endl;
-    jb::testing::create_random_timeseries(generator, size, host);
+    int counter = 0;
+    for (auto& v : host) {
+      v = value_type(++counter);
+    }
     boost::compute::copy(host.begin(), host.end(), dev.begin(), queue);
+    queue.finish();
   }
 
   int run() {
@@ -101,6 +128,7 @@ public:
     return static_cast<int>(host.size());
   }
 
+  /// Disable aggressive optimizations
   std::size_t dummy() const {
     return unused;
   }
@@ -112,68 +140,36 @@ private:
   std::size_t unused;
 };
 
+/**
+ * Create one of the test-cases for the microbenchmark.
+ */
 template <typename value_type, bool use_gpu>
-void benchmark_test_case(config const& cfg) {
-  boost::compute::device device = jb::opencl::device_selector(cfg.opencl());
-  boost::compute::context context(device);
-  boost::compute::command_queue queue(context, device);
-  typedef jb::testing::microbenchmark<fixture<value_type, use_gpu>> benchmark;
-  benchmark bm(cfg.benchmark());
+std::function<void(config const&)> benchmark_test_case() {
+  return [](config const& cfg) {
+    boost::compute::device device = jb::opencl::device_selector(cfg.opencl());
+    boost::compute::context context(device);
+    boost::compute::command_queue queue(context, device);
 
-  auto r = bm.run(context, queue);
-  bm.typical_output(r);
+    using benchmark = jb::testing::microbenchmark<fixture<value_type, use_gpu>>;
+    benchmark bm(cfg.microbenchmark());
+
+    auto r = bm.run(context, queue);
+    bm.typical_output(r);
+  };
 }
 
+/// A table with all the microbenchmark cases
+jb::testing::microbenchmark_group<config> create_testcases() {
+  return jb::testing::microbenchmark_group<config>{
+      {"gpu:complex:float", benchmark_test_case<std::complex<float>, true>()},
+      {"gpu:complex:double", benchmark_test_case<std::complex<double>, true>()},
+      {"cpu:complex:float", benchmark_test_case<std::complex<float>, false>()},
+      {"cpu:complex:double",
+       benchmark_test_case<std::complex<double>, false>()},
+      {"gpu:float", benchmark_test_case<float, true>()},
+      {"gpu:double", benchmark_test_case<double, true>()},
+      {"cpu:float", benchmark_test_case<float, false>()},
+      {"cpu:double", benchmark_test_case<double, false>()},
+  };
+}
 } // anonymous namespace
-
-int main(int argc, char* argv[]) try {
-  config cfg;
-  cfg.benchmark(
-         jb::testing::microbenchmark_config().test_case("gpu:complex:float"))
-      .process_cmdline(argc, argv);
-
-  std::cerr << "Configuration for test\n" << cfg << std::endl;
-
-  auto test_case = cfg.benchmark().test_case();
-  if (test_case == "gpu:complex:float") {
-    benchmark_test_case<std::complex<float>, true>(cfg);
-  } else if (test_case == "gpu:complex:double") {
-    benchmark_test_case<std::complex<double>, true>(cfg);
-  } else if (test_case == "cpu:complex:float") {
-    benchmark_test_case<std::complex<float>, false>(cfg);
-  } else if (test_case == "cpu:complex:double") {
-    benchmark_test_case<std::complex<double>, false>(cfg);
-  } else if (test_case == "gpu:float") {
-    benchmark_test_case<float, true>(cfg);
-  } else if (test_case == "gpu:double") {
-    benchmark_test_case<double, true>(cfg);
-  } else if (test_case == "cpu:float") {
-    benchmark_test_case<float, false>(cfg);
-  } else if (test_case == "cpu:double") {
-    benchmark_test_case<double, false>(cfg);
-  } else {
-    std::ostringstream os;
-    os << "Unknown test case (" << test_case << ")" << std::endl;
-    os << " --test-case must be one of"
-       << ": gpu:complex:float"
-       << ", gpu:complex:double"
-       << ", cpu:complex:float"
-       << ", cpu:complex:double"
-       << ", gpu:float"
-       << ", gpu:double"
-       << ", cpu:float"
-       << ", cpu:double" << std::endl;
-    throw jb::usage(os.str(), 1);
-  }
-
-  return 0;
-} catch (jb::usage const& ex) {
-  std::cerr << "usage: " << ex.what() << std::endl;
-  return ex.exit_status();
-} catch (std::exception const& ex) {
-  std::cerr << "standard exception raised: " << ex.what() << std::endl;
-  return 1;
-} catch (...) {
-  std::cerr << "unknown exception raised" << std::endl;
-  return 1;
-}

--- a/jb/tde/bm_reduce_argmax_real.cpp
+++ b/jb/tde/bm_reduce_argmax_real.cpp
@@ -1,9 +1,8 @@
-#include <jb/opencl/config.hpp>
+#include <jb/opencl/microbenchmark_config.hpp>
 #include <jb/opencl/device_selector.hpp>
 #include <jb/testing/microbenchmark.hpp>
 #include <jb/testing/microbenchmark_group_main.hpp>
 #include <jb/complex_traits.hpp>
-#include <jb/log.hpp>
 
 #include <boost/compute/algorithm/max_element.hpp>
 #include <boost/compute/container/vector.hpp>
@@ -16,16 +15,7 @@
 /// Functions and types to benchmark the argmax reduction based on
 /// Boost.Compute
 namespace {
-class config : public jb::config_object {
-public:
-  config();
-  config_object_constructors(config);
-
-  jb::config_attribute<config, jb::testing::microbenchmark_config>
-      microbenchmark;
-  jb::config_attribute<config, jb::log::config> log;
-  jb::config_attribute<config, jb::opencl::config> opencl;
-};
+using config = jb::opencl::microbenchmark_config;
 
 /// Return a table with all the testcases ..
 jb::testing::microbenchmark_group<config> create_testcases();
@@ -37,14 +27,6 @@ int main(int argc, char* argv[]) {
 }
 
 namespace {
-config::config()
-    : microbenchmark(
-          desc("microbenchmark", "microbenchmark"), this,
-          jb::testing::microbenchmark_config().test_case("gpu:float"))
-    , log(desc("log", "log"), this)
-    , opencl(desc("opencl", "opencl"), this) {
-}
-
 constexpr int default_size() {
   return 32768;
 }

--- a/jb/tde/bm_reduce_argmax_real.cpp
+++ b/jb/tde/bm_reduce_argmax_real.cpp
@@ -1,5 +1,5 @@
-#include <jb/opencl/microbenchmark_config.hpp>
 #include <jb/opencl/device_selector.hpp>
+#include <jb/opencl/microbenchmark_config.hpp>
 #include <jb/testing/microbenchmark.hpp>
 #include <jb/testing/microbenchmark_group_main.hpp>
 #include <jb/complex_traits.hpp>

--- a/jb/testing/microbenchmark_group_main.cpp
+++ b/jb/testing/microbenchmark_group_main.cpp
@@ -21,7 +21,7 @@ int microbenchmark_group_main(
   if (testcase == testcases.end()) {
     std::ostringstream os;
     os << "Unknown test case (" << cfg.test_case() << ")\n";
-    os << " --microbenchmark.test-case must be one of:";
+    os << " --test-case must be one of:";
     for (auto const& i : testcases) {
       os << "  " << i.first << "\n";
     }


### PR DESCRIPTION
Most microbenchmarks that use test cases follow a common pattern, I refactored them to use a template function, to stop repeating myself.
