### PR TITLE
Create the development images before building.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,8 @@ services:
 
 # This is the main section of the automated build ...
 script:
-  # ... first download the docker image with the development environment ...
-  - docker pull ${IMAGE?}
-  # ... print out its Id for historic purposes ...
-  - docker image inspect -f '{{ .Id }}' ${IMAGE?}
   # ... run the build inside the docker image, use the current user id ...
-  - docker run --rm -it --env CONFIGUREFLAGS=${CONFIGUREFLAGS} --env CXX=${COMPILER?} --env CXXFLAGS="${CXXFLAGS}" --volume $PWD:$PWD --workdir $PWD ${IMAGE?} ci/build-in-docker.sh
+  - docker run --rm -it --env CONFIGUREFLAGS=${CONFIGUREFLAGS} --env CXX=${COMPILER?} --env CXXFLAGS="${CXXFLAGS}" --volume $PWD:$PWD --workdir $PWD ${IMAGE?}:tip ci/build-in-docker.sh
   # ... print out the test results, that way any errors can be
   # debugged, this is *not* part of the build script because we want
   # this output regardless of the sucess or failure of the script ...
@@ -48,7 +44,16 @@ before_install:
   - sudo apt-get install docker-engine
 
 install:
+  # Install coveralls-lcov for the code coverage builds only ...
   - if [ "x${COVERAGE}" = "xyes" ]; then gem install coveralls-lcov ; fi
+  # ... first download the current docker image with the development
+  # environment ... 
+  - docker pull ${IMAGE?}
+  - docker image inspect -f '{{ .Id }}' ${IMAGE?}:latest
+  # ... update the image using the latest Dockerfile, and possibly
+  # rebuild from scratch if the existing image is too old ...
+  - ci/create-build-image.sh
+  - docker image inspect -f '{{ .Id }}' ${IMAGE?}:tip
 
 after_success:
   - cd ${TRAVIS_BUILD_DIR?}
@@ -59,7 +64,7 @@ after_success:
   # and push it to github ...
   - ci/gendocs.sh
   # ... on the right builds, create the build image and push to docker ...
-  - ci/create-build-image.sh
+  - ci/upload-build-image.sh
   # ... on the right builds, create the runtime image and push to docker ...
   - ci/create-runtime-image.sh
   # ... on the right builds, create the analysis image and push to docker ...

--- a/ci/create-build-image.sh
+++ b/ci/create-build-image.sh
@@ -2,21 +2,6 @@
 
 set -e
 
-if [ "x${CREATE_BUILD_IMAGE}" != "xyes" ]; then
-    echo "Build image creation not enabled on this build."
-    exit 0
-fi
-
-if [ "x${TRAVIS_PULL_REQUEST}" != "xfalse" ]; then
-    echo "Testing PR, image creation disabled."
-    exit 0
-fi
-
-if [ "x${TRAVIS_BRANCH}" != "xmaster" ]; then
-    echo "DEBUG: only create images on master branch."
-    exit 0
-fi
-
 # Extract the variant from the IMAGE environment variable (it is set
 # in .travis.yml) ...
 IMAGE=$(echo ${IMAGE?} | sed  -e 's/:.*//')
@@ -38,35 +23,5 @@ fi
 # Build a new docker image
 sudo docker image build ${caching?} -t ${IMAGE?}:tip \
        -f docker/dev/${variant?}/Dockerfile docker/dev
-
-if [ -z "${DOCKER_USER}" -o -z "${DOCKER_PASSWORD}" ]; then
-    echo "DOCKER_USER / DOCKER_PASSWORD not set, docker push disabled."
-    exit 0
-fi
-
-sudo docker login -u "${DOCKER_USER?}" -p "${DOCKER_PASSWORD?}"
-
-# Compare the ids of the :tip and :latest ...
-id_tip=$(sudo docker inspect -f '{{ .Id }}' ${IMAGE?}:tip)
-id_latest=$(sudo docker inspect -f '{{ .Id }}' ${IMAGE?}:latest)
-if [ ${id_tip?} != ${id_latest?} ]; then
-    # They are different, we need to push them.  Create a permanent
-    # label so we can keep a history of used images in the registry
-    tag=$(date +%Y%m%d%H%M)
-    echo "${IMAGE?} has changed, pushing to registry."
-    echo "tip    = ${id_tip?}"
-    echo "latest = ${id_latest?}"
-    # ... label the image with the new tag ...
-    sudo docker image tag ${IMAGE?}:tip ${IMAGE?}:${tag?}
-    # ... upload the image with that tag ...
-    sudo docker image push ${IMAGE?}:${tag?}
-    # ... if that succeeds then rename :latest and push it.  The
-    # second push should take almost no time, as the layers should all
-    # be uploaded already ...
-    sudo docker image tag ${IMAGE?}:${tag?} ${IMAGE?}:latest
-    sudo docker image push ${IMAGE?}:latest
-else
-    echo "No changes in ${IMAGE?}, not pushing to registry."
-fi
 
 exit 0

--- a/ci/upload-build-image.sh
+++ b/ci/upload-build-image.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+if [ "x${CREATE_BUILD_IMAGE}" != "xyes" ]; then
+    echo "Build image creation not enabled on this build."
+    exit 0
+fi
+
+if [ "x${TRAVIS_PULL_REQUEST}" != "xfalse" ]; then
+    echo "Testing PR, image creation disabled."
+    exit 0
+fi
+
+if [ "x${TRAVIS_BRANCH}" != "xmaster" ]; then
+    echo "DEBUG: only create images on master branch."
+    exit 0
+fi
+
+if [ -z "${DOCKER_USER}" -o -z "${DOCKER_PASSWORD}" ]; then
+    echo "DOCKER_USER / DOCKER_PASSWORD not set, docker push disabled."
+    exit 0
+fi
+
+sudo docker login -u "${DOCKER_USER?}" -p "${DOCKER_PASSWORD?}"
+
+# Compare the ids of the :tip and :latest ...
+id_tip=$(sudo docker inspect -f '{{ .Id }}' ${IMAGE?}:tip)
+id_latest=$(sudo docker inspect -f '{{ .Id }}' ${IMAGE?}:latest)
+if [ ${id_tip?} != ${id_latest?} ]; then
+    # They are different, we need to push them.  Create a permanent
+    # label so we can keep a history of used images in the registry
+    tag=$(date +%Y%m%d%H%M)
+    echo "${IMAGE?} has changed, pushing to registry."
+    echo "tip    = ${id_tip?}"
+    echo "latest = ${id_latest?}"
+    # ... label the image with the new tag ...
+    sudo docker image tag ${IMAGE?}:tip ${IMAGE?}:${tag?}
+    # ... upload the image with that tag ...
+    sudo docker image push ${IMAGE?}:${tag?}
+    # ... if that succeeds then rename :latest and push it.  The
+    # second push should take almost no time, as the layers should all
+    # be uploaded already ...
+    sudo docker image tag ${IMAGE?}:${tag?} ${IMAGE?}:latest
+    sudo docker image push ${IMAGE?}:latest
+else
+    echo "No changes in ${IMAGE?}, not pushing to registry."
+fi
+
+exit 0

--- a/jb/clfft/plan.hpp
+++ b/jb/clfft/plan.hpp
@@ -237,9 +237,11 @@ private:
  * in execute() must have the same size as this parameter.
  * @param in the input data prototype.  The actual input in
  * execute() must have the same size as this parameter.
- * @param context a collection of devices in a single OpenCL platform.
- * @param queue a command queue associated with @a context to create
+ * @param ct a collection of devices in a single OpenCL platform.
+ * @param q a command queue associated with @a ct to create
  * and bake the plan.
+ * @param batch_size the number of timeseries in the input and output
+ * vectors.
  *
  * @returns a new plan that computes a DFT from a vector like @a in
  * into a vector like @a out.
@@ -265,10 +267,11 @@ plan<invector, outvector> create_forward_plan_1d(
  * in execute() must have the same size as this parameter.
  * @param in the input data prototype.  The actual input in
  * execute() must have the same size as this parameter.
- * @param context a collection of devices in a single OpenCL platform.
- * @param queue a command queue associated with @a context to create
+ * @param ct a collection of devices in a single OpenCL platform.
+ * @param q a command queue associated with @a ct to create
  * and bake the plan.
- * @param batch_size the number of timeseries in the vector.
+ * @param batch_size the number of timeseries in the input and output
+ * vectors.
  *
  * @returns a new plan that computes a DFT from a vector like @a in
  * into a vector like @a out.

--- a/jb/fftw/ut_time_delay_estimator_many.cpp
+++ b/jb/fftw/ut_time_delay_estimator_many.cpp
@@ -18,9 +18,7 @@ BOOST_AUTO_TEST_CASE(fftw_time_delay_estimator_many_3_dim_tde_with_0) {
   int const nsamples = 1 << 15;
   int const S = 20;
   int const V = 4;
-  int const argmax_tol = 1;
-  // we use a very rough approximation to the confidence error here ...
-  int const confidence_tol = nsamples;
+  int const confidence_tol = 1;
 
   using array_type = jb::fftw::aligned_multi_array<float, 3>;
   using tested_type = jb::fftw::time_delay_estimator_many<array_type>;
@@ -60,18 +58,13 @@ BOOST_AUTO_TEST_CASE(fftw_time_delay_estimator_many_3_dim_tde_with_0) {
 
   // run the TDE...
   tested.estimate_delay(confidence, argmax, a, b, sum2);
-  // check argmax within delay +/- tol
-  BOOST_CHECK_MESSAGE(
-      jb::testing::check_collection_close_enough(
-          argmax, expected_argmax, argmax_tol),
-      "argmax is not within tolerance("
-          << argmax_tol << "), argmax[0]=" << argmax[0]
-          << ", expected_argmax[0]=" << expected_argmax[0]);
   // check confidence within nsamples +/- tol
   BOOST_CHECK_MESSAGE(
       jb::testing::check_collection_close_enough(
           confidence, expected_confidence, confidence_tol),
       "confidence is not within tolerance(" << confidence_tol << ")");
+  // we do not check the value of argmax because in this case it is
+  // meaningless, any value in the range is equally invalid.
 }
 
 /**


### PR DESCRIPTION
This is part of the fixes for #129.  We want to create the docker
images for the development environment before we build the code,
that way the code tests verify that the image is usable, and we
can try out the images in a branch.