### PR TITLE
Adapt jb/itch5/ut_mold_udp_channel test to new travis-ci.org environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,6 @@ script:
   - docker pull ${IMAGE?}
   # ... print out its Id for historic purposes ...
   - docker image inspect -f '{{ .Id }}' ${IMAGE?}
-  # ... [DEBUG] print out the networking details ...
-  - ifconfig -a || echo "no ifconfig"
-  - ip link show || echo "no ip link"
-  - iptables -L || echo "no iptables"
   # ... run the build inside the docker image, use the current user id ...
   - docker run --rm -it --env CONFIGUREFLAGS=${CONFIGUREFLAGS} --env CXX=${COMPILER?} --env CXXFLAGS="${CXXFLAGS}" --volume $PWD:$PWD --workdir $PWD ${IMAGE?} ci/build-in-docker.sh
   # ... print out the test results, that way any errors can be

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ script:
   - docker pull ${IMAGE?}
   # ... print out its Id for historic purposes ...
   - docker image inspect -f '{{ .Id }}' ${IMAGE?}
+  # ... [DEBUG] print out the networking details ...
+  - ifconfig -a || echo "no ifconfig"
+  - ip link show || echo "no ip link"
+  - iptables -L || echo "no iptables"
   # ... run the build inside the docker image, use the current user id ...
   - docker run --rm -it --env CONFIGUREFLAGS=${CONFIGUREFLAGS} --env CXX=${COMPILER?} --env CXXFLAGS="${CXXFLAGS}" --volume $PWD:$PWD --workdir $PWD ${IMAGE?} ci/build-in-docker.sh
   # ... print out the test results, that way any errors can be

--- a/jb/itch5/ut_mold_udp_channel.cpp
+++ b/jb/itch5/ut_mold_udp_channel.cpp
@@ -60,9 +60,10 @@ create_mold_udp_packet(std::uint64_t sequence_number, int message_count) {
 std::string select_localhost_address(boost::asio::io_service& io) {
   for (auto const& addr : {"::1", "127.0.0.1"}) {
     try {
-      BOOST_TEST_MESSAGE("Trying to use " << addr
-                         << " as the localhost address");
+      BOOST_TEST_CHECKPOINT("Checking " << addr
+                            << " as the localhost address");
       auto socket = jb::itch5::make_socket_udp_recv(io, addr, 40000, "");
+      BOOST_TEST_CHECKPOINT("Using " << addr << " as the localhost");
       return addr;
     } catch(...) {}
   }


### PR DESCRIPTION
The Travis-CI environment got a little more restrictive with respect to IPv4 / IPv6 addresses.  Fixed the test to work when the host does not have a IPv6 loopback.
