### PR TITLE
Enable Coverity Scan builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,11 +72,7 @@ install:
   - ci/create-build-image.sh
   - docker image inspect -f '{{ .Id }}' ${IMAGE?}:tip
   # ... if necessary, download Coverity ...
-  - ls -l coverity
   - if [ "x${COVERITY}" = "xyes" ]; then ci/coverity-install.sh; fi
-  - ls -l coverity
-  - ls -l coverity/cov-analysis-linux64-8.7.0 || echo "not found 1"
-  - ls -l coverity/cov-analysis-linux64-8.7.0/bin || echo "not found 2"
 
 after_success:
   - cd ${TRAVIS_BUILD_DIR?}

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,6 @@ install:
   - ci/create-build-image.sh
   - docker image inspect -f '{{ .Id }}' ${IMAGE?}:tip
   # ... if necessary, download Coverity ...
-  - ls -l ../coverity
   - ls -l coverity
   - if [ "x${COVERITY}" = "xyes" ]; then ci/coverity-install.sh; fi
   - ls -l coverity

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,14 +31,14 @@ services:
 # This is the main section of the automated build ...
 script:
   # ... run the build inside the docker image, use the current user id ...
-  - docker run --rm -it \
-    --env CONFIGUREFLAGS=${CONFIGUREFLAGS} \
-    --env CXX=${COMPILER?} \
-    --env CXXFLAGS="${CXXFLAGS}" \
-    --env VALGRIND="${VALGRIND}" \
-    --volume $PWD:$PWD \
+  - docker run --rm -it
+    --env CONFIGUREFLAGS=${CONFIGUREFLAGS}
+    --env CXX=${COMPILER?}
+    --env CXXFLAGS="${CXXFLAGS}"
+    --env VALGRIND="${VALGRIND}"
+    --volume $PWD:$PWD
     --volume ${TRAVIS_BUILD_DIR?}/coverity:/opt/coverity
-    --workdir $PWD \
+    --workdir $PWD
     ${IMAGE?}:tip ci/build-in-docker.sh
   # ... print out the test results, that way any errors can be
   # debugged, this is *not* part of the build script because we want

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install docker-engine
 
+cache:
+  directories:
+    - coverity
+
 install:
   # Install coveralls-lcov for the code coverage builds only ...
   - if [ "x${COVERAGE}" = "xyes" ]; then gem install coveralls-lcov ; fi
@@ -58,6 +62,10 @@ install:
   # rebuild from scratch if the existing image is too old ...
   - ci/create-build-image.sh
   - docker image inspect -f '{{ .Id }}' ${IMAGE?}:tip
+  # ... if necessary, download Coverity ...
+  - ci/coverity-install.sh
+  - ls -l coverity*
+  - ls -l .
 
 after_success:
   - cd ${TRAVIS_BUILD_DIR?}

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,8 @@ install:
   - ls -l coverity
   - if [ "x${COVERITY}" = "xyes" ]; then ci/coverity-install.sh; fi
   - ls -l coverity
+  - ls -l coverity/cov-analysis-linux64-8.7.0 || echo "not found 1"
+  - ls -l coverity/cov-analysis-linux64-8.7.0/bin || echo "not found 2"
 
 after_success:
   - cd ${TRAVIS_BUILD_DIR?}

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
   - ci/create-build-image.sh
   - docker image inspect -f '{{ .Id }}' ${IMAGE?}:tip
   # ... if necessary, download Coverity ...
-  - if [ "x${COVERITY}" = "xyes" ]; then ../ci/coverity-install.sh; fi
+  - if [ "x${COVERITY}" = "xyes" ]; then ci/coverity-install.sh; fi
   - ls -l coverity
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
 
     - os: linux
       compiler: gcc
-      env: IMAGE=coryan/jaybeamsdev-fedora25 COMPILER=g++ CXXFLAGS=-O3 GENDOCS=yes CONFIGUREFLAGS="" CREATE_BUILD_IMAGE=yes CREATE_RUNTIME_IMAGE=yes
+      env: IMAGE=coryan/jaybeamsdev-fedora25 COMPILER=g++ CXXFLAGS=-O3 COVERITY=yes GENDOCS=yes CONFIGUREFLAGS="" CREATE_BUILD_IMAGE=yes CREATE_RUNTIME_IMAGE=yes
 
     - os: linux
       compiler: gcc
@@ -31,7 +31,15 @@ services:
 # This is the main section of the automated build ...
 script:
   # ... run the build inside the docker image, use the current user id ...
-  - docker run --rm -it --env CONFIGUREFLAGS=${CONFIGUREFLAGS} --env CXX=${COMPILER?} --env CXXFLAGS="${CXXFLAGS}" --env VALGRIND="${VALGRIND}" --volume $PWD:$PWD --workdir $PWD ${IMAGE?}:tip ci/build-in-docker.sh
+  - docker run --rm -it \
+    --env CONFIGUREFLAGS=${CONFIGUREFLAGS} \
+    --env CXX=${COMPILER?} \
+    --env CXXFLAGS="${CXXFLAGS}" \
+    --env VALGRIND="${VALGRIND}" \
+    --volume $PWD:$PWD \
+    --volume ${TRAVIS_BUILD_DIR?}/coverity:/opt/coverity
+    --workdir $PWD \
+    ${IMAGE?}:tip ci/build-in-docker.sh
   # ... print out the test results, that way any errors can be
   # debugged, this is *not* part of the build script because we want
   # this output regardless of the sucess or failure of the script ...
@@ -63,9 +71,8 @@ install:
   - ci/create-build-image.sh
   - docker image inspect -f '{{ .Id }}' ${IMAGE?}:tip
   # ... if necessary, download Coverity ...
-  - ci/coverity-install.sh
-  - ls -l coverity*
-  - ls -l .
+  - if [ "x${COVERITY}" = "xyes" ]; then ../ci/coverity-install.sh; fi
+  - ls -l coverity
 
 after_success:
   - cd ${TRAVIS_BUILD_DIR?}

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ script:
     --env CXX=${COMPILER?}
     --env CXXFLAGS="${CXXFLAGS}"
     --env VALGRIND="${VALGRIND}"
+    --env COVERITY="${COVERITY}"
     --volume $PWD:$PWD
     --volume ${TRAVIS_BUILD_DIR?}/coverity:/opt/coverity
     --workdir $PWD
@@ -71,6 +72,8 @@ install:
   - ci/create-build-image.sh
   - docker image inspect -f '{{ .Id }}' ${IMAGE?}:tip
   # ... if necessary, download Coverity ...
+  - ls -l ../coverity
+  - ls -l coverity
   - if [ "x${COVERITY}" = "xyes" ]; then ci/coverity-install.sh; fi
   - ls -l coverity
 
@@ -82,6 +85,8 @@ after_success:
   # ... create the Doxygen documentation inside the docker container,
   # and push it to github ...
   - ci/gendocs.sh
+  # ... upload the coverity results ...
+  - ci/coverity-upload.sh
   # ... on the right builds, create the build image and push to docker ...
   - ci/upload-build-image.sh
   # ... on the right builds, create the runtime image and push to docker ...

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![coveralls](https://coveralls.io/repos/coryan/jaybeams/badge.svg?branch=master&service=github)](https://coveralls.io/github/coryan/jaybeams?branch=master)
 [![codecov](https://codecov.io/gh/coryan/jaybeams/branch/master/graph/badge.svg)](https://codecov.io/gh/coryan/jaybeams)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/79c4108849884f4cb71e70597089f9cf)](https://www.codacy.com/app/coryan/jaybeams?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=coryan/jaybeams&amp;utm_campaign=Badge_Grade)
+[![Coverity Scan](https://scan.coverity.com/projects/jaybeams2)](https://img.shields.io/coverity/scan/12813.svg)
 [![Documentation](https://img.shields.io/badge/documentation-master-brightgreen.svg)](http://coryan.github.io/jaybeams/)
 
 Another project to have fun coding.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![coveralls](https://coveralls.io/repos/coryan/jaybeams/badge.svg?branch=master&service=github)](https://coveralls.io/github/coryan/jaybeams?branch=master)
 [![codecov](https://codecov.io/gh/coryan/jaybeams/branch/master/graph/badge.svg)](https://codecov.io/gh/coryan/jaybeams)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/79c4108849884f4cb71e70597089f9cf)](https://www.codacy.com/app/coryan/jaybeams?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=coryan/jaybeams&amp;utm_campaign=Badge_Grade)
-[![Coverity Scan](https://scan.coverity.com/projects/jaybeams2)](https://img.shields.io/coverity/scan/12813.svg)
+[![Coverity Scan](https://img.shields.io/coverity/scan/12813.svg)](https://scan.coverity.com/projects/jaybeams2)
 [![Documentation](https://img.shields.io/badge/documentation-master-brightgreen.svg)](http://coryan.github.io/jaybeams/)
 
 Another project to have fun coding.

--- a/ci/build-in-docker.sh
+++ b/ci/build-in-docker.sh
@@ -15,7 +15,12 @@ cd build
 ../configure ${CONFIGUREFLAGS} --prefix=$PWD/staging || cat config.log
 
 # ... compile and run the tests ...
-make -j 2 check
+if [ "x${COVERITY}" = "xyes" ]; then
+    export PATH=$PATH:/opt/cov-analysis-linux64-8.7.0/bin
+    cov-build --dir cov-int make -j 2 check
+else
+    make -j 2 check
+fi
 
 if [ "x${VALGRIND}" = "xyes" ]; then
     make -j 2 check-valgrind-memcheck

--- a/ci/build-in-docker.sh
+++ b/ci/build-in-docker.sh
@@ -15,10 +15,13 @@ cd build
 ../configure ${CONFIGUREFLAGS} --prefix=$PWD/staging || cat config.log
 
 # ... compile and run the tests ...
-if [ "x${COVERITY}" = "xyes" ]; then
+if [ "x${COVERITY}" = "xyes" -o "x${TRAVIS_PULL_REQUEST}" = "xfalse" ]; then
+    # ... coverity builds are slow, so we disable them for pull
+    # requests, where they cannot be uploaded anyway ...
     PATH=$PATH:/opt/coverity/cov-analysis-linux64-8.7.0/bin
     export PATH
     cov-build --dir cov-int make -j 2 check
+    tar zcf jaybeams-coverity-upload.tgz cov-int
 else
     make -j 2 check
 fi

--- a/ci/build-in-docker.sh
+++ b/ci/build-in-docker.sh
@@ -15,7 +15,19 @@ cd build
 ../configure ${CONFIGUREFLAGS} --prefix=$PWD/staging || cat config.log
 
 # ... compile and run the tests ...
-if [ "x${COVERITY}" = "xyes" -o "x${TRAVIS_PULL_REQUEST}" = "xfalse" ]; then
+do_coverity=no
+if [ "x${TRAVIS_PULL_REQUEST}" = "xfalse" ]; then
+    # Always skip Coverity Scan builds for PR ...
+    :
+elif [ "x${TRAVIS_BRANCH}" != "xmaster" ]; then
+    # ... and for branches other than master ...
+    :
+elif [ "x${TRAVIS_EVENT_TYPE}" = "xcron" -a "x${COVERITY}" = "xyes" ]; then
+    # ... and really, only do them weekly ...
+    do_coverity=yes
+fi
+
+if [ "x$do_coverity" = "xyes" ]; then
     # ... coverity builds are slow, so we disable them for pull
     # requests, where they cannot be uploaded anyway ...
     PATH=$PATH:/opt/coverity/cov-analysis-linux64-8.7.0/bin

--- a/ci/build-in-docker.sh
+++ b/ci/build-in-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
@@ -16,7 +16,8 @@ cd build
 
 # ... compile and run the tests ...
 if [ "x${COVERITY}" = "xyes" ]; then
-    export PATH=$PATH:/opt/cov-analysis-linux64-8.7.0/bin
+    PATH=$PATH:/opt/coverity/cov-analysis-linux64-8.7.0/bin
+    export PATH
     cov-build --dir cov-int make -j 2 check
 else
     make -j 2 check

--- a/ci/coverity-install.sh
+++ b/ci/coverity-install.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -e
+
+wget -q https://scan.coverity.com/download/linux64 \
+     --post-data "token=${COVERITY_TOKEN?}&project=jaybeams2&md5=1" \
+     -O coverity_tool.md5
+
+test -r coverity_tool.current.md5 || touch coverity_tool.current.md5
+
+if cmp -s coverity_tool.md5 coverity_tool.current.md5; then
+    :
+else
+    wget -q https://scan.coverity.com/download/linux64 \
+         --post-data "token=${COVERITY_TOKEN?}&project=jaybeams2" \
+         -O coverity_tool.tgz
+    cp  coverity_tool.md5 coverity_tool.current.md5
+fi
+
+tar xf coverity_tool.tgz
+
+exit 0
+

--- a/ci/coverity-install.sh
+++ b/ci/coverity-install.sh
@@ -13,15 +13,16 @@ wget -q https://scan.coverity.com/download/linux64 \
 test -r coverity_tool.current.md5 || touch coverity_tool.current.md5
 
 if cmp -s coverity_tool.md5 coverity_tool.current.md5; then
-    :
+    echo "Coverity Scan is up to date, no download required."
 else
+    echo "Downloading Coverity Scan..."
     wget -q https://scan.coverity.com/download/linux64 \
          --post-data "token=${COVERITY_TOKEN?}&project=jaybeams2" \
-         -O coverity_tool.tgz
-    cp  coverity_tool.md5 coverity_tool.current.md5
+         -O coverity_tool.tgz && \
+        tar xf coverity_tool.tgz && \
+        cp  coverity_tool.md5 coverity_tool.current.md5
+    echo "   done."
 fi
-
-tar xf coverity_tool.tgz
 
 exit 0
 

--- a/ci/coverity-install.sh
+++ b/ci/coverity-install.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+cd ${TRAVIS_BUILD_DIR?}
+test -d coverity || mkdir coverity
+cd coverity
+
 wget -q https://scan.coverity.com/download/linux64 \
      --post-data "token=${COVERITY_TOKEN?}&project=jaybeams2&md5=1" \
      -O coverity_tool.md5

--- a/ci/coverity-model.cpp
+++ b/ci/coverity-model.cpp
@@ -1,0 +1,1 @@
+// Empty model file for Coverity Scan

--- a/ci/coverity-upload.sh
+++ b/ci/coverity-upload.sh
@@ -7,18 +7,9 @@ if [ "x${TRAVIS_PULL_REQUEST}" != "xfalse" -o "x${COVERITY}" != "xyes" ]; then
     exit 0
 fi
 
-ls -l
-ls -l build/cov-int
-tar zcf jaybeams.tgz -C build cov-int
-
-if [ "x${TRAVIS_BRANCH}" != "xmaster" ]; then
-    echo "DEBUG: only create images on master branch."
-    exit 0
-fi
-
 curl --form token=${COVERITY_TOKEN?} \
   --form email=coryan@users.noreply.github.com \
-  --form file=@jaybeams.tgz \
+  --form file=@jaybeams-coverity-upload.tgz \
   --form version=$(git rev-parse --short HEAD) \
   --form description="Manual Build" \
   https://scan.coverity.com/builds?project=jaybeams2

--- a/ci/coverity-upload.sh
+++ b/ci/coverity-upload.sh
@@ -2,17 +2,17 @@
 
 set -e
 
-tar zcf jaybeams.tgz -C build cov-int
-
-if [ "x${TRAVIS_PULL_REQUEST}" != "xfalse" ]; then
-    echo "Testing PR, image creation disabled."
+if [ "x${TRAVIS_PULL_REQUEST}" != "xfalse" -o "x${COVERITY}" != "xyes" ]; then
+    echo "Build is a pull request or COVERITY is not 'yes', aborting."
     exit 0
 fi
 
+ls -l
+ls -l build/cov-int
+tar zcf jaybeams.tgz -C build cov-int
+
 if [ "x${TRAVIS_BRANCH}" != "xmaster" ]; then
     echo "DEBUG: only create images on master branch."
-    ls -l
-    ls -l build/cov-int
     exit 0
 fi
 

--- a/ci/coverity-upload.sh
+++ b/ci/coverity-upload.sh
@@ -7,6 +7,11 @@ if [ "x${TRAVIS_PULL_REQUEST}" != "xfalse" -o "x${COVERITY}" != "xyes" ]; then
     exit 0
 fi
 
+if [ ! -r build/jaybeams-coverity-upload.tgz ]; then
+    echo "No coverity output, skipping upload."
+    exit 0
+fi
+
 curl --form token=${COVERITY_TOKEN?} \
   --form email=coryan@users.noreply.github.com \
   --form file=@build/jaybeams-coverity-upload.tgz \

--- a/ci/coverity-upload.sh
+++ b/ci/coverity-upload.sh
@@ -9,9 +9,9 @@ fi
 
 curl --form token=${COVERITY_TOKEN?} \
   --form email=coryan@users.noreply.github.com \
-  --form file=@jaybeams-coverity-upload.tgz \
+  --form file=@build/jaybeams-coverity-upload.tgz \
   --form version=$(git rev-parse --short HEAD) \
-  --form description="Manual Build" \
+  --form description="Travis-CI Build, branch=${TRAVIS_BRANCH}" \
   https://scan.coverity.com/builds?project=jaybeams2
 
 exit 0

--- a/ci/coverity-upload.sh
+++ b/ci/coverity-upload.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+tar zcf jaybeams.tgz -C build cov-int
+
+if [ "x${TRAVIS_PULL_REQUEST}" != "xfalse" ]; then
+    echo "Testing PR, image creation disabled."
+    exit 0
+fi
+
+if [ "x${TRAVIS_BRANCH}" != "xmaster" ]; then
+    echo "DEBUG: only create images on master branch."
+    ls -l
+    ls -l build/cov-int
+    exit 0
+fi
+
+curl --form token=${COVERITY_TOKEN?} \
+  --form email=coryan@users.noreply.github.com \
+  --form file=@jaybeams.tgz \
+  --form version=$(git rev-parse --short HEAD) \
+  --form description="Manual Build" \
+  https://scan.coverity.com/builds?project=jaybeams2
+
+exit 0

--- a/jb/as_hhmmss.cpp
+++ b/jb/as_hhmmss.cpp
@@ -1,15 +1,19 @@
 #include "jb/as_hhmmss.hpp"
 
+#include <boost/io/ios_state.hpp>
+
 #include <iomanip>
 #include <iostream>
 
 std::ostream& jb::operator<<(std::ostream& os, jb::as_hhmmssu const& x) {
+  boost::io::ios_flags_saver saver(os);
   auto usec = x.t.count() % 1000000;
   return os << jb::as_hhmmss(x.t) << '.' << std::setw(6) << std::setfill('0')
             << usec;
 }
 
 std::ostream& jb::operator<<(std::ostream& os, jb::as_hhmmss const& x) {
+  boost::io::ios_flags_saver saver(os);
   auto t = x.t.count() / 1000000;
   auto ss = t % 60;
   t /= 60;
@@ -22,6 +26,7 @@ std::ostream& jb::operator<<(std::ostream& os, jb::as_hhmmss const& x) {
 }
 
 std::ostream& jb::operator<<(std::ostream& os, jb::as_hh_mm_ss_u const& x) {
+  boost::io::ios_flags_saver saver(os);
   auto usec = x.t.count() % 1000000;
   auto t = x.t.count() / 1000000;
   auto ss = t % 60;

--- a/jb/clfft/init.cpp
+++ b/jb/clfft/init.cpp
@@ -7,7 +7,7 @@ jb::clfft::init::init() {
   jb::clfft::check_error_code(err, "clfftSetup");
 }
 
-jb::clfft::init::~init() {
+jb::clfft::init::~init() noexcept(false) {
   auto err = clfftTeardown();
   jb::clfft::check_error_code(err, "clfftTeardown");
 }

--- a/jb/clfft/init.hpp
+++ b/jb/clfft/init.hpp
@@ -13,7 +13,7 @@ namespace clfft {
 class init {
 public:
   init();
-  ~init();
+  ~init() noexcept(false);
 
   //@{
   /**

--- a/jb/clfft/plan.hpp
+++ b/jb/clfft/plan.hpp
@@ -73,7 +73,7 @@ public:
   }
 
   /// Destructor, cleanup the plan.
-  ~plan() {
+  ~plan() noexcept(false) {
     check_constraints checker;
     if (d_ == ENDDIRECTION) {
       return;

--- a/jb/config_files_location.cpp
+++ b/jb/config_files_location.cpp
@@ -74,13 +74,15 @@ bool jb::default_validator::operator()(fs::path const& dir) {
 char const* jb::sysconfdir() {
 #if defined(JB_SYSCONFDIR)
   return JB_SYSCONFDIR;
-#endif // JB_SYSCONFDIR
+#else
   return JB_DEFAULT_SYSCONFDIR;
+#endif // JB_SYSCONFDIR
 }
 
 char const* jb::bindir() {
 #if defined(JB_BINDIR)
   return JB_BINDIR;
-#endif // JB_BINDIR
+#else
   return JB_DEFAULT_BINDIR;
+#endif // JB_BINDIR
 }

--- a/jb/itch5/price_field.hpp
+++ b/jb/itch5/price_field.hpp
@@ -4,6 +4,7 @@
 #include <jb/itch5/base_decoders.hpp>
 #include <jb/itch5/static_digits.hpp>
 
+#include <boost/io/ios_state.hpp>
 #include <boost/operators.hpp>
 
 #include <iomanip>
@@ -120,6 +121,7 @@ struct decoder<validate, price_field<wire_type_t, denom_v>> {
 template <typename wire_type_t, std::intmax_t denom_v>
 std::ostream&
 operator<<(std::ostream& os, price_field<wire_type_t, denom_v> const& x) {
+  boost::io::ios_flags_saver saver(os);
   auto d = std::div(x.as_integer(), x.denom);
   return os << d.quot << "." << std::setw(x.denom_digits - 1)
             << std::setfill('0') << d.rem;

--- a/jb/opencl/bm_generic_reduce.cpp
+++ b/jb/opencl/bm_generic_reduce.cpp
@@ -135,6 +135,7 @@ public:
       , generator_(
             jb::testing::initialize_mersenne_twister<std::mt19937_64>(
                 0, jb::testing::default_initialization_marker))
+      , iteration_size_(0)
       , avoid_optimization_(0)
       , cfg_(cfg) {
     int counter = 0;

--- a/jb/testing/create_triangle_timeseries.hpp
+++ b/jb/testing/create_triangle_timeseries.hpp
@@ -39,7 +39,7 @@ void create_triangle_timeseries(int nsamples, boost::multi_array<T, K, A>& ts) {
   /// The values stored in the input timeseries
   using value_type = T;
   assert(jb::detail::nsamples(ts) == static_cast<std::size_t>(nsamples));
-  float p4 = nsamples / 4;
+  float p4 = nsamples / 4.0F;
   int num_timeseries = jb::detail::element_count(ts) / nsamples;
   // fill the first timeseries
   int count = 0;

--- a/jb/testing/create_triangle_timeseries.hpp
+++ b/jb/testing/create_triangle_timeseries.hpp
@@ -16,7 +16,7 @@ template <typename timeseries>
 void create_triangle_timeseries(int nsamples, timeseries& ts) {
   resize_if_applicable(ts, nsamples);
   using value_type = typename timeseries::value_type;
-  float p4 = nsamples / 4;
+  float p4 = nsamples / 4.0F;
   for (int i = 0; i != nsamples / 2; ++i) {
     ts[i] = value_type((i - p4) / p4);
     ts[i + nsamples / 2] = value_type((p4 - i) / p4);

--- a/jb/testing/microbenchmark_base.cpp
+++ b/jb/testing/microbenchmark_base.cpp
@@ -41,7 +41,8 @@ void jb::testing::microbenchmark_base::write_results(
   }
 }
 
-jb::testing::microbenchmark_base::summary::summary(results const& arg) {
+jb::testing::microbenchmark_base::summary::summary(results const& arg)
+    : summary() {
   results r = arg;
   auto cmp = [](result const& lhs, result const& rhs) {
     return lhs.second < rhs.second;

--- a/jb/testing/microbenchmark_base.hpp
+++ b/jb/testing/microbenchmark_base.hpp
@@ -32,7 +32,16 @@ public:
    * A simple object to contain the summary of the test results
    */
   struct summary {
-    summary() {
+    summary()
+        : min(0)
+        , p25(0)
+        , p50(0)
+        , p75(0)
+        , p90(0)
+        , p99(0)
+        , p99_9(0)
+        , max(0)
+        , n(0) {
     }
     explicit summary(results const& arg);
 

--- a/jb/ut_config_object.cpp
+++ b/jb/ut_config_object.cpp
@@ -281,8 +281,8 @@ BOOST_AUTO_TEST_CASE(config_object_vector_empty) {
   std::istringstream is("");
   char argv0[] = "not_a_path";
   char argv1[] = "--vars.0.pos.x=2";
-  char* argv[] = {argv0, argv1};
-  int argc = sizeof(argv) / sizeof(argv[0]);
+  char* argv[] = {argv0, argv1, nullptr};
+  int argc = sizeof(argv) / sizeof(argv[0]) - 1;
   tested.load_overrides(argc, argv, is);
 
   BOOST_REQUIRE_EQUAL(tested.vars().size(), 1);
@@ -401,8 +401,8 @@ pos:
 
   config1 tested;
   char argv0[] = "not_a_path";
-  char* argv[] = {argv0};
-  int argc = sizeof(argv) / sizeof(argv[0]);
+  char* argv[] = {argv0, nullptr};
+  int argc = sizeof(argv) / sizeof(argv[0]) - 1;
 
   tested.load_overrides(argc, argv, is);
 
@@ -436,8 +436,8 @@ pos:
   char argv3[] = "--list=3";
   char argv4[] = "--list=5";
   char argv5[] = "--list=7";
-  char* argv[] = {argv0, argv1, argv2, argv3, argv4, argv5};
-  int argc = sizeof(argv) / sizeof(argv[0]);
+  char* argv[] = {argv0, argv1, argv2, argv3, argv4, argv5, nullptr};
+  int argc = sizeof(argv) / sizeof(argv[0]) - 1;
 
   tested.load_overrides(argc, argv, is);
 
@@ -455,8 +455,8 @@ BOOST_AUTO_TEST_CASE(config_object_usage) {
   config1 tested;
   char argv0[] = "binary";
   char argv1[] = "--help";
-  char* argv[] = {argv0, argv1};
-  int argc = sizeof(argv) / sizeof(argv[0]);
+  char* argv[] = {argv0, argv1, nullptr};
+  int argc = sizeof(argv) / sizeof(argv[0]) - 1;
   std::istringstream is("");
 
   BOOST_CHECK_THROW(tested.load_overrides(argc, argv, is), jb::usage);
@@ -470,8 +470,8 @@ BOOST_AUTO_TEST_CASE(config_object_invalid_option) {
   config1 tested;
   char argv0[] = "binary";
   char argv1[] = "--invalid-option";
-  char* argv[] = {argv0, argv1};
-  int argc = sizeof(argv) / sizeof(argv[0]);
+  char* argv[] = {argv0, argv1, nullptr};
+  int argc = sizeof(argv) / sizeof(argv[0]) - 1;
   std::istringstream is("");
 
   BOOST_CHECK_THROW(tested.load_overrides(argc, argv, is), std::exception);
@@ -524,8 +524,8 @@ foo:
   char argv0[] = "binary";
   char argv1[] = "--foo.first=42";
   char argv2[] = "--foo.second=43";
-  char* argv[] = {argv0, argv1, argv2};
-  int argc = sizeof(argv) / sizeof(argv[0]);
+  char* argv[] = {argv0, argv1, argv2, nullptr};
+  int argc = sizeof(argv) / sizeof(argv[0]) - 1;
   tested.load_overrides(argc, argv, is);
 
   BOOST_CHECK_EQUAL(tested.foo().first, 42);
@@ -590,8 +590,8 @@ baz:
   char argv0[] = "binary";
   char argv1[] = "--bar.x=42";
   char argv2[] = "--baz.y=24";
-  char* argv[] = {argv0, argv1, argv2};
-  int argc = sizeof(argv) / sizeof(argv[0]);
+  char* argv[] = {argv0, argv1, argv2, nullptr};
+  int argc = sizeof(argv) / sizeof(argv[0]) - 1;
   config6 tested;
   tested.load_overrides(argc, argv, filename, "TEST_ROOT");
   BOOST_CHECK_EQUAL(tested.foo(), "this is a long string");
@@ -619,8 +619,8 @@ BOOST_AUTO_TEST_CASE(config_object_config_file_missing_with_env) {
   char argv0[] = "binary";
   char argv1[] = "--bar.x=42";
   char argv2[] = "--baz.y=24";
-  char* argv[] = {argv0, argv1, argv2};
-  int argc = sizeof(argv) / sizeof(argv[0]);
+  char* argv[] = {argv0, argv1, argv2, nullptr};
+  int argc = sizeof(argv) / sizeof(argv[0]) - 1;
   config6 tested;
   tested.load_overrides(argc, argv, filename, "TEST_ROOT");
   BOOST_CHECK_EQUAL(tested.foo(), "");
@@ -666,8 +666,8 @@ baz:
   char argv0[] = "binary";
   char argv1[] = "--bar.x=42";
   char argv2[] = "--baz.y=24";
-  char* argv[] = {argv0, argv1, argv2};
-  int argc = sizeof(argv) / sizeof(argv[0]);
+  char* argv[] = {argv0, argv1, argv2, nullptr};
+  int argc = sizeof(argv) / sizeof(argv[0]) - 1;
   config6 tested;
   tested.load_overrides(argc, argv, filename);
   BOOST_CHECK_EQUAL(tested.foo(), "this is a long string");
@@ -685,8 +685,8 @@ BOOST_AUTO_TEST_CASE(config_object_config_file_missing) {
   char argv0[] = "binary";
   char argv1[] = "--foo=this is a long string";
   char argv2[] = "--baz.y=24";
-  char* argv[] = {argv0, argv1, argv2};
-  int argc = sizeof(argv) / sizeof(argv[0]);
+  char* argv[] = {argv0, argv1, argv2, nullptr};
+  int argc = sizeof(argv) / sizeof(argv[0]) - 1;
   config6 tested;
   tested.load_overrides(argc, argv, filename);
   BOOST_CHECK_EQUAL(tested.foo(), "this is a long string");
@@ -721,8 +721,8 @@ BOOST_AUTO_TEST_CASE(config_object_positional) {
   char argv1[] = "should-be-bar";
   char argv2[] = "should-be-baz";
   char argv3[] = "--foo=another";
-  char* argv[] = {argv0, argv1, argv2, argv3};
-  int argc = sizeof(argv) / sizeof(argv[0]);
+  char* argv[] = {argv0, argv1, argv2, argv3, nullptr};
+  int argc = sizeof(argv) / sizeof(argv[0]) - 1;
   config7 tested;
   tested.load_overrides(argc, argv, is);
   BOOST_CHECK_EQUAL(tested.foo(), "another");


### PR DESCRIPTION
This should fix #3 the cron builds for master will run a Coverity Scan and upload the results.  We only do it for cron builds because Coverity Scan takes twice as long as a regular build, and I do not want to block the workflow waiting for it.
